### PR TITLE
make googlepb compile with gcc < 4.5.1

### DIFF
--- a/upb/upb.h
+++ b/upb/upb.h
@@ -127,15 +127,15 @@
   template <>                                                     \
   class Pointer<cppname> : public PointerBase<cppname, cppbase> { \
    public:                                                        \
-    explicit Pointer(cppname* ptr) :                              \
-    PointerBase<cppname, cppbase>(ptr) {}                         \
+    explicit Pointer(cppname* ptr)                                \
+        : PointerBase<cppname, cppbase>(ptr) {}                   \
   };                                                              \
   template <>                                                     \
   class Pointer<const cppname>                                    \
       : public PointerBase<const cppname, const cppbase> {        \
    public:                                                        \
-    explicit Pointer(const cppname* ptr) :                        \
-    PointerBase<const cppname, const cppbase>(ptr) {}             \
+    explicit Pointer(const cppname* ptr)                          \
+        : PointerBase<const cppname, const cppbase>(ptr) {}       \
   };                                                              \
   }
 
@@ -147,15 +147,15 @@
   template <>                                                                \
   class Pointer<cppname> : public PointerBase2<cppname, cppbase, cppbase2> { \
    public:                                                                   \
-    explicit Pointer(cppname* ptr) :                                         \
-    PointerBase2<cppname, cppbase, cppbase2>(ptr) {}                         \
+    explicit Pointer(cppname* ptr)                                           \
+        : PointerBase2<cppname, cppbase, cppbase2>(ptr) {}                   \
   };                                                                         \
   template <>                                                                \
   class Pointer<const cppname>                                               \
       : public PointerBase2<const cppname, const cppbase, const cppbase2> {  \
    public:                                                                   \
-    explicit Pointer(const cppname* ptr) :                                   \
-    PointerBase2<const cppname, const cppbase, const cppbase2>(ptr) {}       \
+    explicit Pointer(const cppname* ptr)                                     \
+        : PointerBase2<const cppname, const cppbase, const cppbase2>(ptr) {} \
   };                                                                         \
   }
 

--- a/upb/upb.h
+++ b/upb/upb.h
@@ -127,13 +127,15 @@
   template <>                                                     \
   class Pointer<cppname> : public PointerBase<cppname, cppbase> { \
    public:                                                        \
-    explicit Pointer(cppname* ptr) : PointerBase(ptr) {}          \
+    explicit Pointer(cppname* ptr) :                              \
+    PointerBase<cppname, cppbase>(ptr) {}                         \
   };                                                              \
   template <>                                                     \
   class Pointer<const cppname>                                    \
       : public PointerBase<const cppname, const cppbase> {        \
    public:                                                        \
-    explicit Pointer(const cppname* ptr) : PointerBase(ptr) {}    \
+    explicit Pointer(const cppname* ptr) :                        \
+    PointerBase<const cppname, const cppbase>(ptr) {}             \
   };                                                              \
   }
 
@@ -145,13 +147,15 @@
   template <>                                                                \
   class Pointer<cppname> : public PointerBase2<cppname, cppbase, cppbase2> { \
    public:                                                                   \
-    explicit Pointer(cppname* ptr) : PointerBase2(ptr) {}                    \
+    explicit Pointer(cppname* ptr) :                                         \
+    PointerBase2<cppname, cppbase, cppbase2>(ptr) {}                         \
   };                                                                         \
   template <>                                                                \
   class Pointer<const cppname>                                               \
       : public PointerBase2<const cppname, const cppbase, const cppbase2> {  \
    public:                                                                   \
-    explicit Pointer(const cppname* ptr) : PointerBase2(ptr) {}              \
+    explicit Pointer(const cppname* ptr) :                                   \
+    PointerBase2<const cppname, const cppbase, const cppbase2>(ptr) {}       \
   };                                                                         \
   }
 


### PR DESCRIPTION
```
$ make Q= googlepb
g++ -O3 -std=c++98 -pedantic -Wno-long-long -Wall -Wextra -Wpointer-arith -Wno-unused-private-field -I. -DNDEBUG   -c -o obj/upb/bindings/googlepb/bridge.o upb/bindings/googlepb/bridge.cc
In file included from ./upb/handlers.h:22,
                 from ./upb/bindings/googlepb/bridge.h:42,
                 from upb/bindings/googlepb/bridge.cc:8:
./upb/def.h: In constructor ‘upb::Pointer<upb::Def>::Pointer(upb::Def*)’:
./upb/def.h:39: error: class ‘upb::Pointer<upb::Def>’ does not have any field named ‘PointerBase’
./upb/def.h:39: error: no matching function for call to ‘upb::PointerBase<upb::Def, upb::RefCounted>::PointerBase()’
./upb/upb.h:246: note: candidates are: upb::PointerBase<T, Base>::PointerBase(T*) [with T = upb::Def, Base = upb::RefCounted]
./upb/upb.h:244: note:                 upb::PointerBase<upb::Def, upb::RefCounted>::PointerBase(const upb::PointerBase<upb::Def, upb::RefCounted>&)
...
```
the generated code looks like:
```
template <> class Pointer<upb::Def> : public PointerBase<upb::Def, upb::RefCounted> {
    public: explicit Pointer(upb::Def* ptr) : PointerBase(ptr) {}
};
```

which falls into https://gcc.gnu.org/bugzilla/show_bug.cgi?id=189
(http://stackoverflow.com/questions/8887864/template-base-constructor-call-in-member-initialization-list-error)

changing the generated code to:
```
template <> class Pointer<upb::Def> : public PointerBase<upb::Def, upb::RefCounted> {
    public: explicit Pointer(upb::Def* ptr) : PointerBase<upb::Def, upb::RefCounted>(ptr) {}
};
```
makes it compile at least on 4.4.7 that we are testing with:
```
$ gcc -v
Using built-in specs.
Target: x86_64-redhat-linux
Configured with: ../configure --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-bootstrap --enable-shared --enable-threads=posix --enable-checking=release --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions
--enable-gnu-unique-object --enable-languages=c,c++,objc,obj-c++,java,fortran,ada --enable-java-awt=gtk --disable-dssi --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-1.5.0.0/jre --enable-libgcj-multifile --enable-java-maintainer-mode --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --disable-libjava-multilib
--with-ppl --with-cloog --with-tune=generic --with-arch_32=i686 --build=x86_64-redhat-linux
Thread model: posix
gcc version 4.4.7 20120313 (Red Hat 4.4.7-4) (GCC)
```