### PR TITLE
Added migration flag for users using old JSON format.

### DIFF
--- a/upb/json/parser.c
+++ b/upb/json/parser.c
@@ -1627,13 +1627,23 @@ static void add_jsonname_table(upb_json_parsermethod *m, const upb_msgdef* md) {
       !upb_msg_field_done(&i);
       upb_msg_field_next(&i)) {
     const upb_fielddef *f = upb_msg_iter_field(&i);
+
     size_t field_len = upb_fielddef_getjsonname(f, buf, len);
     if (field_len > len) {
+      size_t len2;
       buf = realloc(buf, field_len);
       len = field_len;
-      upb_fielddef_getjsonname(f, buf, len);
+      len2 = upb_fielddef_getjsonname(f, buf, len);
+      UPB_ASSERT_VAR(len2, len == len2);
     }
     upb_strtable_insert(t, buf, upb_value_constptr(f));
+
+    if (getenv("UPB_JSON_ACCEPT_LEGACY_FIELD_NAMES")) {
+      /* Temporary code to help people migrate if they were depending on the
+       * old, non-proto3-json-compliant field names.  In this case we
+       * recognize both old names and new names. */
+      upb_strtable_insert(t, upb_fielddef_name(f), upb_value_constptr(f));
+    }
 
     if (upb_fielddef_issubmsg(f)) {
       add_jsonname_table(m, upb_fielddef_msgsubdef(f));

--- a/upb/json/parser.rl
+++ b/upb/json/parser.rl
@@ -1362,6 +1362,7 @@ static void add_jsonname_table(upb_json_parsermethod *m, const upb_msgdef* md) {
       !upb_msg_field_done(&i);
       upb_msg_field_next(&i)) {
     const upb_fielddef *f = upb_msg_iter_field(&i);
+
     size_t field_len = upb_fielddef_getjsonname(f, buf, len);
     if (field_len > len) {
       size_t len2;
@@ -1371,6 +1372,13 @@ static void add_jsonname_table(upb_json_parsermethod *m, const upb_msgdef* md) {
       UPB_ASSERT_VAR(len2, len == len2);
     }
     upb_strtable_insert(t, buf, upb_value_constptr(f));
+
+    if (getenv("UPB_JSON_ACCEPT_LEGACY_FIELD_NAMES")) {
+      /* Temporary code to help people migrate if they were depending on the
+       * old, non-proto3-json-compliant field names.  In this case we
+       * recognize both old names and new names. */
+      upb_strtable_insert(t, upb_fielddef_name(f), upb_value_constptr(f));
+    }
 
     if (upb_fielddef_issubmsg(f)) {
       add_jsonname_table(m, upb_fielddef_msgsubdef(f));


### PR DESCRIPTION
This is intended for Ruby users who may currently be using JSON format. The Ruby JSON format was written before we realized that proto3 JSON would be camelCasing field names, so it always used original field names. The most recent upb code fixes this problem, but this could cause problems for any Ruby users who are currently using JSON.

These Ruby users should migrate, but it may be difficult to do all at once. So we are providing these flags for now to make the migration easier.

In the longer term, if Ruby users need compatibility with existing payloads, they should use the `json_name` option in their `.proto` files to specify the old names. Unfortunately proto3 Ruby doesn't support `json_name` yet. We will add support for it before we remove these flags.