### PR TITLE
Fix musl libc incompatibility

### DIFF
--- a/tests/pb/test_decoder.cc
+++ b/tests/pb/test_decoder.cc
@@ -111,7 +111,7 @@ using std::string;
 
 void vappendf(string* str, const char *format, va_list args) {
   va_list copy;
-  __va_copy(copy, args);
+  _upb_va_copy(copy, args);
 
   int count = vsnprintf(NULL, 0, format, args);
   if (count >= 0)

--- a/upb/upb.h
+++ b/upb/upb.h
@@ -51,8 +51,8 @@ template <int N> class InlinedEnvironment;
 #define UPB_NORETURN
 #endif
 
-#if __STDC_VERSION__ >= 199901L
-/* C99 versions. */
+#if __STDC_VERSION__ >= 199901L || __cplusplus >= 201103L
+/* C99/C++11 versions. */
 #include <stdio.h>
 #define _upb_snprintf snprintf
 #define _upb_vsnprintf vsnprintf

--- a/upb/upb.h
+++ b/upb/upb.h
@@ -51,20 +51,21 @@ template <int N> class InlinedEnvironment;
 #define UPB_NORETURN
 #endif
 
+#if __STDC_VERSION__ >= 199901L
+/* C99 versions. */
+#include <stdio.h>
+#define _upb_snprintf snprintf
+#define _upb_vsnprintf vsnprintf
+#define _upb_va_copy(a, b) va_copy(a, b)
+#elif defined __GNUC__
 /* A few hacky workarounds for functions not in C89.
  * For internal use only!
  * TODO(haberman): fix these by including our own implementations, or finding
  * another workaround.
  */
-#ifdef __GNUC__
 #define _upb_snprintf __builtin_snprintf
 #define _upb_vsnprintf __builtin_vsnprintf
 #define _upb_va_copy(a, b) __va_copy(a, b)
-#elif __STDC_VERSION__ >= 199901L
-/* C99 versions. */
-#define _upb_snprintf snprintf
-#define _upb_vsnprintf vsnprintf
-#define _upb_va_copy(a, b) va_copy(a, b)
 #else
 #error Need implementations of [v]snprintf and va_copy
 #endif


### PR DESCRIPTION
This library is not compatible with musl libc because the `__va_copy` function is glibc internal function.
I found the problem when I am trying to use protobuf in ruby. ( See https://github.com/google/protobuf/issues/2335#issuecomment-259887751
 )

The incompatibility can be fixed by using standard `va_copy` function whenever it is being built in C99( and C99-compatible C++11 ). 

It is testable using the following Dockerfile.

```
FROM alpine

RUN apk update
RUN apk add build-base

WORKDIR /root

COPY . ./

RUN make CFLAGS='-std=c99'
RUN make CFLAGS='-std=c99' CXXFLAGS='-std=c++11' tests test
```