### PR TITLE
Simplify and remove some code from upb::SymbolTable

### DIFF
--- a/tests/bindings/lua/test_upb.lua
+++ b/tests/bindings/lua/test_upb.lua
@@ -403,42 +403,6 @@ function test_symtab()
   assert_equal(msgdef3:field("field5"):subdef(), msgdef2)
 end
 
-function test_symtab_add_extension()
-  -- Adding an extension at the same time as the extendee.
-  local symtab = upb.SymbolTable{
-    upb.MessageDef{full_name = "M1"},
-    upb.FieldDef{name = "extension1", is_extension = true, number = 1,
-                 type = upb.TYPE_INT32, containing_type_name = "M1"}
-  }
-
-  local m1 = symtab:lookup("M1")
-  assert_not_nil(m1)
-  assert_equal(1, #m1)
-
-  local f1 = m1:field("extension1")
-  assert_not_nil(f1)
-  assert_true(f1:is_extension())
-  assert_true(f1:is_frozen())
-  assert_equal(1, f1:number())
-
-  -- Adding an extension to an existing extendee.
-  symtab:add{
-    upb.FieldDef{name = "extension2", is_extension = true, number = 2,
-                 type = upb.TYPE_INT32, containing_type_name = "M1"}
-  }
-
-  local m1_2 = symtab:lookup("M1")
-  assert_not_nil(m1_2)
-  assert_true(m1 ~= m1_2)
-  assert_equal(2, #m1_2)
-
-  local f2 = m1_2:field("extension2")
-  assert_not_nil(f2)
-  assert_true(f2:is_extension())
-  assert_true(f2:is_frozen())
-  assert_equal(2, f2:number())
-end
-
 function test_numeric_array()
   local function test_for_numeric_type(upb_type, val, too_big, too_small, bad3)
     local array = upb.Array(upb_type)

--- a/tests/bindings/lua/test_upb.lua
+++ b/tests/bindings/lua/test_upb.lua
@@ -401,17 +401,6 @@ function test_symtab()
   local msgdef3 = symtab:lookup("ContainingMessage2")
   assert_not_nil(msgdef3)
   assert_equal(msgdef3:field("field5"):subdef(), msgdef2)
-
-  -- Freeze the symtab and verify that mutating operations are not allowed.
-  assert_false(symtab:is_frozen())
-  symtab:freeze()
-  assert_true(symtab:is_frozen())
-  assert_error_match("frozen", function() symtab:freeze() end)
-  assert_error_match("frozen", function()
-    symtab:add{
-      upb.MessageDef{full_name = "Foo"}
-    }
-  end)
 end
 
 function test_symtab_add_extension()

--- a/tests/test_cpp.cc
+++ b/tests/test_cpp.cc
@@ -154,15 +154,12 @@ static void TestSymbolTable(const char *descriptor_file) {
     exit(1);
   }
 
-  upb::reffed_ptr<upb::SymbolTable> s(upb::SymbolTable::New());
+  upb::SymbolTable* s = upb::SymbolTable::New();
 
   for (size_t i = 0; i < files.size(); i++) {
     ASSERT(s->AddFile(files[i].get(), &status));
   }
 
-  ASSERT(!s->IsFrozen());
-  s->Freeze();
-  ASSERT(s->IsFrozen());
   upb::reffed_ptr<const upb::MessageDef> md(s->LookupMessage("C"));
   ASSERT(md.get());
 
@@ -180,6 +177,7 @@ static void TestSymbolTable(const char *descriptor_file) {
 #endif
 
   ASSERT(md.get());
+  upb::SymbolTable::Free(s);
 }
 
 static void TestCasts1() {

--- a/tests/test_def.c
+++ b/tests/test_def.c
@@ -220,6 +220,7 @@ static void test_replacement_fails() {
   newdefs[1] = upb_msgdef_upcast_mutable(m2);
   ok = upb_symtab_add(s, newdefs, 2, &s, &status);
   ASSERT(ok == false);
+  upb_status_clear(&status);
 
   /* Adding just one is ok. */
   ASSERT_STATUS(upb_symtab_add(s, newdefs, 1, &s, &status), &status);

--- a/tests/test_def.c
+++ b/tests/test_def.c
@@ -164,7 +164,7 @@ static void test_symbol_resolution() {
 
 static void test_fielddef_unref() {
   bool ok;
-  upb_symtab *s = load_test_proto(&s);
+  upb_symtab *s = load_test_proto();
   const upb_msgdef *md = upb_symtab_lookupmsg(s, "A");
   const upb_fielddef *f = upb_msgdef_itof(md, 1);
   upb_fielddef_ref(f, &f);

--- a/upb/bindings/lua/upb.h
+++ b/upb/bindings/lua/upb.h
@@ -101,7 +101,7 @@ void *lupb_refcounted_check(lua_State *L, int narg, const char *type);
 const upb_msgdef *lupb_msgdef_check(lua_State *L, int narg);
 const upb_enumdef *lupb_enumdef_check(lua_State *L, int narg);
 const upb_fielddef *lupb_fielddef_check(lua_State *L, int narg);
-const upb_symtab *lupb_symtab_check(lua_State *L, int narg);
+upb_symtab *lupb_symtab_check(lua_State *L, int narg);
 
 void lupb_refcounted_pushnewrapper(lua_State *L, const upb_refcounted *obj,
                                    const char *type, const void *ref_donor);

--- a/upb/def.c
+++ b/upb/def.c
@@ -378,13 +378,14 @@ bool _upb_def_validate(upb_def *const*defs, size_t n, upb_status *s) {
     } else if (def->type == UPB_DEF_FIELD) {
       upb_status_seterrmsg(s, "standalone fielddefs can not be frozen");
       goto err;
-    } else if (def->type == UPB_DEF_ENUM) {
-      if (!upb_validate_enumdef(upb_dyncast_enumdef(def), s)) {
-        goto err;
-      }
     } else {
       /* Set now to detect transitive closure in the second pass. */
       def->came_from_user = true;
+
+      if (def->type == UPB_DEF_ENUM &&
+          !upb_validate_enumdef(upb_dyncast_enumdef(def), s)) {
+        goto err;
+      }
     }
   }
 

--- a/upb/def.c
+++ b/upb/def.c
@@ -2237,15 +2237,9 @@ static bool symtab_add(upb_symtab *s, upb_def *const*defs, size_t n,
   for (i = 0; i < add_n; i++) {
     upb_def *def = (upb_def*)add_objs[i];
     const char *name = upb_def_fullname(def);
-    upb_value v;
     bool success;
-
-    if (upb_strtable_remove(&s->symtab, name, &v)) {
-      const upb_def *def = upb_value_getptr(v);
-      upb_def_unref(def, s);
-    }
     success = upb_strtable_insert(&s->symtab, name, upb_value_ptr(def));
-    UPB_ASSERT(success == true);
+    UPB_ASSERT(success);
   }
   upb_gfree(add_defs);
   return true;

--- a/upb/def.h
+++ b/upb/def.h
@@ -44,8 +44,7 @@ UPB_DECLARE_DERIVED_TYPE(upb::OneofDef, upb::RefCounted, upb_oneofdef,
                          upb_refcounted)
 UPB_DECLARE_DERIVED_TYPE(upb::FileDef, upb::RefCounted, upb_filedef,
                          upb_refcounted)
-UPB_DECLARE_DERIVED_TYPE(upb::SymbolTable, upb::RefCounted,
-                         upb_symtab, upb_refcounted)
+UPB_DECLARE_TYPE(upb::SymbolTable, upb_symtab)
 
 
 /* The maximum message depth that the type graph can have.  This is a resource
@@ -1434,10 +1433,8 @@ class upb::SymbolTable {
  public:
   /* Returns a new symbol table with a single ref owned by "owner."
    * Returns NULL if memory allocation failed. */
-  static reffed_ptr<SymbolTable> New();
-
-  /* Include RefCounted base methods. */
-  UPB_REFCOUNTED_CPPMETHODS
+  static SymbolTable* New();
+  static void Free(upb::SymbolTable* table);
 
   /* For all lookup functions, the returned pointer is not owned by the
    * caller; it may be invalidated by any non-const call or unref of the
@@ -1527,11 +1524,8 @@ UPB_BEGIN_EXTERN_C
 
 /* Native C API. */
 
-/* Include refcounted methods like upb_symtab_ref(). */
-UPB_REFCOUNTED_CMETHODS(upb_symtab, upb_symtab_upcast)
-
-upb_symtab *upb_symtab_new(const void *owner);
-void upb_symtab_freeze(upb_symtab *s);
+upb_symtab *upb_symtab_new();
+void upb_symtab_free(upb_symtab* s);
 const upb_def *upb_symtab_resolve(const upb_symtab *s, const char *base,
                                   const char *sym);
 const upb_def *upb_symtab_lookup(const upb_symtab *s, const char *sym);
@@ -1562,13 +1556,11 @@ UPB_END_EXTERN_C
 #ifdef __cplusplus
 /* C++ inline wrappers. */
 namespace upb {
-inline reffed_ptr<SymbolTable> SymbolTable::New() {
-  upb_symtab *s = upb_symtab_new(&s);
-  return reffed_ptr<SymbolTable>(s, &s);
+inline SymbolTable* SymbolTable::New() {
+  return upb_symtab_new();
 }
-
-inline void SymbolTable::Freeze() {
-  return upb_symtab_freeze(this);
+inline void SymbolTable::Free(SymbolTable* s) {
+  upb_symtab_free(s);
 }
 inline const Def *SymbolTable::Resolve(const char *base,
                                        const char *sym) const {

--- a/upb/def.h
+++ b/upb/def.h
@@ -79,8 +79,6 @@ class upb::Def {
  public:
   typedef upb_deftype_t Type;
 
-  Def* Dup(const void *owner) const;
-
   /* upb::RefCounted methods like Ref()/Unref(). */
   UPB_REFCOUNTED_CPPMETHODS
 
@@ -125,9 +123,6 @@ class upb::Def {
 #endif  /* __cplusplus */
 
 UPB_BEGIN_EXTERN_C
-
-/* Native C API. */
-upb_def *upb_def_dup(const upb_def *def, const void *owner);
 
 /* Include upb_refcounted methods like upb_def_ref()/upb_def_unref(). */
 UPB_REFCOUNTED_CMETHODS(upb_def, upb_def_upcast)
@@ -317,13 +312,6 @@ class upb::FieldDef {
 
   /* Returns NULL if memory allocation failed. */
   static reffed_ptr<FieldDef> New();
-
-  /* Duplicates the given field, returning NULL if memory allocation failed.
-   * When a fielddef is duplicated, the subdef (if any) is made symbolic if it
-   * wasn't already.  If the subdef is set but has no name (which is possible
-   * since msgdefs are not required to have a name) the new fielddef's subdef
-   * will be unset. */
-  FieldDef* Dup(const void* owner) const;
 
   /* upb::RefCounted methods like Ref()/Unref(). */
   UPB_REFCOUNTED_CPPMETHODS
@@ -573,7 +561,6 @@ UPB_BEGIN_EXTERN_C
 
 /* Native C API. */
 upb_fielddef *upb_fielddef_new(const void *owner);
-upb_fielddef *upb_fielddef_dup(const upb_fielddef *f, const void *owner);
 
 /* Include upb_refcounted methods like upb_fielddef_ref(). */
 UPB_REFCOUNTED_CMETHODS(upb_fielddef, upb_fielddef_upcast2)
@@ -783,16 +770,6 @@ class upb::MessageDef {
     return FindOneofByName(str.c_str(), str.size());
   }
 
-  /* Returns a new msgdef that is a copy of the given msgdef (and a copy of all
-   * the fields) but with any references to submessages broken and replaced
-   * with just the name of the submessage.  Returns NULL if memory allocation
-   * failed.
-   *
-   * TODO(haberman): which is more useful, keeping fields resolved or
-   * unresolving them?  If there's no obvious answer, Should this functionality
-   * just be moved into symtab.c? */
-  MessageDef* Dup(const void* owner) const;
-
   /* Is this message a map entry? */
   void setmapentry(bool map_entry);
   bool mapentry() const;
@@ -926,7 +903,6 @@ UPB_REFCOUNTED_CMETHODS(upb_msgdef, upb_msgdef_upcast2)
 
 bool upb_msgdef_freeze(upb_msgdef *m, upb_status *status);
 
-upb_msgdef *upb_msgdef_dup(const upb_msgdef *m, const void *owner);
 const char *upb_msgdef_fullname(const upb_msgdef *m);
 const char *upb_msgdef_name(const upb_msgdef *m);
 int upb_msgdef_numoneofs(const upb_msgdef *m);
@@ -1076,10 +1052,6 @@ class upb::EnumDef {
    * first one that was added. */
   const char* FindValueByNumber(int32_t num) const;
 
-  /* Returns a new EnumDef with all the same values.  The new EnumDef will be
-   * owned by the given owner. */
-  EnumDef* Dup(const void* owner) const;
-
   /* Iteration over name/value pairs.  The order is undefined.
    * Adding an enum val invalidates any iterators.
    *
@@ -1107,7 +1079,6 @@ UPB_BEGIN_EXTERN_C
 
 /* Native C API. */
 upb_enumdef *upb_enumdef_new(const void *owner);
-upb_enumdef *upb_enumdef_dup(const upb_enumdef *e, const void *owner);
 
 /* Include upb_refcounted methods like upb_enumdef_ref(). */
 UPB_REFCOUNTED_CMETHODS(upb_enumdef, upb_enumdef_upcast2)
@@ -1217,10 +1188,6 @@ class upb::OneofDef {
   /* Looks up by tag number. */
   const FieldDef* FindFieldByNumber(uint32_t num) const;
 
-  /* Returns a new OneofDef with all the same fields. The OneofDef will be owned
-   * by the given owner. */
-  OneofDef* Dup(const void* owner) const;
-
   /* Iteration over fields.  The order is undefined. */
   class iterator : public std::iterator<std::forward_iterator_tag, FieldDef*> {
    public:
@@ -1266,7 +1233,6 @@ UPB_BEGIN_EXTERN_C
 
 /* Native C API. */
 upb_oneofdef *upb_oneofdef_new(const void *owner);
-upb_oneofdef *upb_oneofdef_dup(const upb_oneofdef *o, const void *owner);
 
 /* Include upb_refcounted methods like upb_oneofdef_ref(). */
 UPB_REFCOUNTED_CMETHODS(upb_oneofdef, upb_oneofdef_upcast)
@@ -1472,20 +1438,11 @@ class upb::SymbolTable {
    * you ask for an iterator of MessageDef the iterated elements are strongly
    * typed as MessageDef*. */
 
-  /* Adds the given mutable defs to the symtab, resolving all symbols
-   * (including enum default values) and finalizing the defs.  Only one def per
-   * name may be in the list, but defs can replace existing defs in the symtab.
+  /* Adds the given mutable defs to the symtab, resolving all symbols (including
+   * enum default values) and finalizing the defs.  Only one def per name may be
+   * in the list, and the defs may not duplicate any name already in the symtab.
    * All defs must have a name -- anonymous defs are not allowed.  Anonymous
    * defs can still be frozen by calling upb_def_freeze() directly.
-   *
-   * Any existing defs that can reach defs that are being replaced will
-   * themselves be replaced also, so that the resulting set of defs is fully
-   * consistent.
-   *
-   * This logic implemented in this method is a convenience; ultimately it
-   * calls some combination of upb_fielddef_setsubdef(), upb_def_dup(), and
-   * upb_freeze(), any of which the client could call themself.  However, since
-   * the logic for doing so is nontrivial, we provide it here.
    *
    * The entire operation either succeeds or fails.  If the operation fails,
    * the symtab is unchanged, false is returned, and status indicates the
@@ -1496,13 +1453,7 @@ class upb::SymbolTable {
    * leave the defs themselves partially resolved.  Does this matter?  If so we
    * could do a prepass that ensures that all symbols are resolvable and bail
    * if not, so we don't mutate anything until we know the operation will
-   * succeed.
-   *
-   * TODO(haberman): since the defs must be mutable, refining a frozen def
-   * requires making mutable copies of the entire tree.  This is wasteful if
-   * only a few messages are changing.  We may want to add a way of adding a
-   * tree of frozen defs to the symtab (perhaps an alternate constructor where
-   * you pass the root of the tree?) */
+   * succeed. */
   bool Add(Def*const* defs, size_t n, void* ref_donor, Status* status);
 
   bool Add(const std::vector<Def*>& defs, void *owner, Status* status) {
@@ -1592,9 +1543,6 @@ UPB_INLINE const char* upb_safecstr(const std::string& str) {
 /* Inline C++ wrappers. */
 namespace upb {
 
-inline Def* Def::Dup(const void* owner) const {
-  return upb_def_dup(this, owner);
-}
 inline Def::Type Def::def_type() const { return upb_def_type(this); }
 inline const char* Def::full_name() const { return upb_def_fullname(this); }
 inline const char* Def::name() const { return upb_def_name(this); }
@@ -1643,9 +1591,6 @@ inline FieldDef::IntegerFormat FieldDef::ConvertIntegerFormat(int32_t val) {
 inline reffed_ptr<FieldDef> FieldDef::New() {
   upb_fielddef *f = upb_fielddef_new(&f);
   return reffed_ptr<FieldDef>(f, &f);
-}
-inline FieldDef* FieldDef::Dup(const void* owner) const {
-  return upb_fielddef_dup(this, owner);
 }
 inline const char* FieldDef::full_name() const {
   return upb_fielddef_fullname(this);
@@ -1886,9 +1831,6 @@ inline const OneofDef* MessageDef::FindOneofByName(const char* name,
                                                    size_t len) const {
   return upb_msgdef_ntoo(this, name, len);
 }
-inline MessageDef* MessageDef::Dup(const void *owner) const {
-  return upb_msgdef_dup(this, owner);
-}
 inline void MessageDef::setmapentry(bool map_entry) {
   upb_msgdef_setmapentry(this, map_entry);
 }
@@ -2057,9 +1999,6 @@ inline bool EnumDef::FindValueByName(const char* name, int32_t *num) const {
 }
 inline const char* EnumDef::FindValueByNumber(int32_t num) const {
   return upb_enumdef_iton(this, num);
-}
-inline EnumDef* EnumDef::Dup(const void* owner) const {
-  return upb_enumdef_dup(this, owner);
 }
 
 inline EnumDef::Iterator::Iterator(const EnumDef* e) {

--- a/upb/msg.c
+++ b/upb/msg.c
@@ -350,7 +350,6 @@ upb_msgfactory *upb_msgfactory_new(const upb_symtab *symtab) {
   upb_msgfactory *ret = upb_gmalloc(sizeof(*ret));
 
   ret->symtab = symtab;
-  upb_symtab_ref(ret->symtab, &ret->symtab);
   upb_inttable_init(&ret->layouts, UPB_CTYPE_PTR);
   upb_inttable_init(&ret->mergehandlers, UPB_CTYPE_CONSTPTR);
 
@@ -373,7 +372,6 @@ void upb_msgfactory_free(upb_msgfactory *f) {
 
   upb_inttable_uninit(&f->layouts);
   upb_inttable_uninit(&f->mergehandlers);
-  upb_symtab_unref(f->symtab, &f->symtab);
   upb_gfree(f);
 }
 


### PR DESCRIPTION
This makes `upb::SymbolTable` no longer refcounted. It also rips out the code to allow replacement of defs in a SymbolTable; this capability was not useful and was buggy. In the future we'll follow the model of the main protobuf implementation: messages can't be redefined.

We do keep some of the legacy "dup" code around because it's currently used for extensions. However we will eventually want to remove this also and handle extensions in a different way.