### PR TITLE
Allows the json parser to ignore unknown fields during parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.s??
 obj/
 lib/
+upb.c
+upb.h

--- a/upb/json/parser.c
+++ b/upb/json/parser.c
@@ -109,6 +109,9 @@ struct upb_json_parsermethod {
 
   /* Keys are upb_msgdef*, values are upb_strtable (json_name -> fielddef) */
   upb_inttable name_tables;
+
+  /* Configurable value to drop unknown fields instead of returning a parse error */
+  bool ignore_unknown_fields;
 };
 
 #define PARSER_CHECK_RETURN(x) if (!(x)) return false
@@ -1038,11 +1041,13 @@ static bool end_membername(upb_json_parser *p) {
 
       return true;
     } else {
-      /* TODO(haberman): Ignore unknown fields if requested/configured to do
-       * so. */
-      upb_status_seterrf(&p->status, "No such field: %.*s\n", (int)len, buf);
-      upb_env_reporterror(p->env, &p->status);
-      return false;
+      if (p->method->ignore_unknown_fields) {
+        return false;
+      } else {
+        upb_status_seterrf(&p->status, "No such field: %.*s\n", (int)len, buf);
+        upb_env_reporterror(p->env, &p->status);
+        return false;
+      }
     }
   }
 }
@@ -1753,13 +1758,14 @@ upb_bytessink *upb_json_parser_input(upb_json_parser *p) {
 }
 
 upb_json_parsermethod *upb_json_parsermethod_new(const upb_msgdef* md,
-                                                 const void* owner) {
+                                                 const void* owner, bool ignore_unknown_fields) {
   static const struct upb_refcounted_vtbl vtbl = {visit_json_parsermethod,
                                                   free_json_parsermethod};
   upb_json_parsermethod *ret = upb_gmalloc(sizeof(*ret));
   upb_refcounted_init(upb_json_parsermethod_upcast_mutable(ret), &vtbl, owner);
 
   ret->msg = md;
+  ret->ignore_unknown_fields = ignore_unknown_fields;
   upb_ref2(md, ret);
 
   upb_byteshandler_init(&ret->input_handler_);

--- a/upb/json/parser.h
+++ b/upb/json/parser.h
@@ -76,7 +76,7 @@ upb_json_parser* upb_json_parser_create(upb_env* e,
 upb_bytessink *upb_json_parser_input(upb_json_parser *p);
 
 upb_json_parsermethod* upb_json_parsermethod_new(const upb_msgdef* md,
-                                                 const void* owner);
+                                                 const void* owner, bool ignore_unknown_fields);
 const upb_handlers *upb_json_parsermethod_desthandlers(
     const upb_json_parsermethod *m);
 const upb_byteshandler *upb_json_parsermethod_inputhandler(
@@ -108,7 +108,7 @@ inline const BytesHandler* ParserMethod::input_handler() const {
 /* static */
 inline reffed_ptr<const ParserMethod> ParserMethod::New(
     const MessageDef* md) {
-  const upb_json_parsermethod *m = upb_json_parsermethod_new(md, &m);
+  const upb_json_parsermethod *m = upb_json_parsermethod_new(md, &m, false);
   return reffed_ptr<const ParserMethod>(m, &m);
 }
 

--- a/upb/json/parser.rl
+++ b/upb/json/parser.rl
@@ -107,6 +107,9 @@ struct upb_json_parsermethod {
 
   /* Keys are upb_msgdef*, values are upb_strtable (json_name -> fielddef) */
   upb_inttable name_tables;
+
+  /* Configurable value to drop unknown fields instead of returning a parse error */
+  bool ignore_unknown_fields;
 };
 
 #define PARSER_CHECK_RETURN(x) if (!(x)) return false
@@ -1036,11 +1039,13 @@ static bool end_membername(upb_json_parser *p) {
 
       return true;
     } else {
-      /* TODO(haberman): Ignore unknown fields if requested/configured to do
-       * so. */
-      upb_status_seterrf(&p->status, "No such field: %.*s\n", (int)len, buf);
-      upb_env_reporterror(p->env, &p->status);
-      return false;
+      if (p->method->ignore_unknown_fields) {
+        return false;
+      } else {
+        upb_status_seterrf(&p->status, "No such field: %.*s\n", (int)len, buf);
+        upb_env_reporterror(p->env, &p->status);
+        return false;
+      }
     }
   }
 }
@@ -1488,12 +1493,13 @@ upb_bytessink *upb_json_parser_input(upb_json_parser *p) {
 }
 
 upb_json_parsermethod *upb_json_parsermethod_new(const upb_msgdef* md,
-                                                 const void* owner) {
+                                                 const void* owner, bool ignore_unknown_fields) {
   static const struct upb_refcounted_vtbl vtbl = {visit_json_parsermethod,
                                                   free_json_parsermethod};
   upb_json_parsermethod *ret = upb_gmalloc(sizeof(*ret));
   upb_refcounted_init(upb_json_parsermethod_upcast_mutable(ret), &vtbl, owner);
 
+  ret->ignore_unknown_fields = ignore_unknown_fields;
   ret->msg = md;
   upb_ref2(md, ret);
 


### PR DESCRIPTION
This change makes it possible to add new fields to an message without
causing breaking changes in older clients.

Unblocks https://github.com/google/protobuf/pull/4304 and fixes https://github.com/google/protobuf/issues/4251