### PR TITLE
Enforced that upb_msg lives in an Arena only, and other simplifying.

### DIFF
--- a/tests/bindings/lua/test_upb.pb.lua
+++ b/tests/bindings/lua/test_upb.pb.lua
@@ -27,25 +27,13 @@ local symtab = upb.SymbolTable{
 local factory = upb.MessageFactory(symtab);
 local TestMessage = factory:get_message_class("TestMessage")
 
-function test_decodermethod()
-  local decoder = pb.MakeStringToMessageDecoder(TestMessage)
-
-  assert_error(
-    function()
-      -- Needs at least one argument to construct.
-      pb.MakeStringToMessageDecoder()
-    end)
-end
-
 function test_parse_primitive()
   local binary_pb =
          "\008\128\128\128\128\002\016\128\128\128\128\004\024\128\128"
       .. "\128\128\128\128\128\002\032\128\128\128\128\128\128\128\001\041\000"
       .. "\000\000\000\000\000\248\063\053\000\000\096\064\056\001"
-  local decoder = pb.MakeStringToMessageDecoder(TestMessage)
-  local encoder = pb.MakeMessageToStringEncoder(TestMessage)
-  collectgarbage()  -- ensure encoder/decoder GC-anchor what they need.
-  local msg = decoder(binary_pb)
+  local msg = TestMessage()
+  pb.decode(msg, binary_pb)
   assert_equal(536870912, msg.i32)
   assert_equal(1073741824, msg.u32)
   assert_equal(1125899906842624, msg.i64)
@@ -54,8 +42,9 @@ function test_parse_primitive()
   assert_equal(3.5, msg.flt)
   assert_equal(true, msg.bool)
 
-  local encoded = encoder(msg)
-  local msg2 = decoder(encoded)
+  local encoded = pb.encode(msg)
+  local msg2 = TestMessage()
+  pb.decode(msg2, encoded)
   assert_equal(536870912, msg.i32)
   assert_equal(1073741824, msg.u32)
   assert_equal(1125899906842624, msg.i64)
@@ -77,8 +66,8 @@ function test_parse_string()
   local TestMessage = factory:get_message_class("TestMessage")
 
   local binary_pb = "\010\005Hello"
-  local decoder = pb.MakeStringToMessageDecoder(TestMessage)
-  msg = decoder(binary_pb)
+  msg = TestMessage()
+  pb.decode(msg, binary_pb)
   assert_equal("Hello", msg.str)
 end
 

--- a/upb/bindings/lua/upb.h
+++ b/upb/bindings/lua/upb.h
@@ -131,11 +131,12 @@ int lupb_arena_new(lua_State *L);
 int lupb_msg_pushref(lua_State *L, int msgclass, void *msg);
 const upb_msg *lupb_msg_checkmsg(lua_State *L, int narg,
                                  const lupb_msgclass *lmsgclass);
+upb_msg *lupb_msg_checkmsg2(lua_State *L, int narg,
+                            const upb_msglayout **layout);
 
 const lupb_msgclass *lupb_msgclass_check(lua_State *L, int narg);
 const upb_msglayout *lupb_msgclass_getlayout(lua_State *L, int narg);
 const upb_msgdef *lupb_msgclass_getmsgdef(const lupb_msgclass *lmsgclass);
-const upb_handlers *lupb_msgclass_getmergehandlers(lua_State *L, int narg);
 upb_msgfactory *lupb_msgclass_getfactory(const lupb_msgclass *lmsgclass);
 void lupb_msg_registertypes(lua_State *L);
 

--- a/upb/bindings/lua/upb/pb.c
+++ b/upb/bindings/lua/upb/pb.c
@@ -6,135 +6,56 @@
 */
 
 #include "upb/bindings/lua/upb.h"
-#include "upb/pb/decoder.h"
-#include "upb/pb/encoder.h"
+#include "upb/decode.h"
+#include "upb/encode.h"
 
 #define LUPB_PBDECODERMETHOD "lupb.pb.decodermethod"
 
-static int lupb_pb_strtomessage(lua_State *L) {
+static int lupb_pb_decode(lua_State *L) {
   size_t len;
   upb_status status = UPB_STATUS_INIT;
-  const char *pb = lua_tolstring(L, 1, &len);
-  const upb_msglayout *layout = lua_touserdata(L, lua_upvalueindex(1));
-  const upb_pbdecodermethod *method = lua_touserdata(L, lua_upvalueindex(2));
-  const upb_handlers *handlers = upb_pbdecodermethod_desthandlers(method);
-
-  upb_arena *msg_arena;
+  const upb_msglayout *layout;
+  upb_msg *msg = lupb_msg_checkmsg2(L, 1, &layout);
+  const char *pb = lua_tolstring(L, 2, &len);
+  upb_stringview buf = upb_stringview_make(pb, len);
   upb_env env;
-  upb_sink sink;
-  upb_pbdecoder *decoder;
-  void *msg;
 
-  lupb_arena_new(L);
-  msg_arena = lupb_arena_check(L, -1);
-
-  msg = upb_msg_new(layout, upb_arena_alloc(msg_arena));
   upb_env_init(&env);
   upb_env_reporterrorsto(&env, &status);
-  upb_sink_reset(&sink, handlers, msg);
-  decoder = upb_pbdecoder_create(&env, method, &sink);
 
-  upb_bufsrc_putbuf(pb, len, upb_pbdecoder_input(decoder));
+  upb_decode(buf, msg, (const void*)layout, &env);
 
   /* Free resources before we potentially bail on error. */
   upb_env_uninit(&env);
   lupb_checkstatus(L, &status);
 
-  /* References the arena at the top of the stack. */
-  lupb_msg_pushref(L, lua_upvalueindex(3), msg);
-  return 1;
+  return 0;
 }
 
-static int lupb_pb_messagetostr(lua_State *L) {
-  const lupb_msgclass *lmsgclass = lua_touserdata(L, lua_upvalueindex(1));
-  const upb_msg *msg = lupb_msg_checkmsg(L, 1, lmsgclass);
-  const upb_visitorplan *vp = lua_touserdata(L, lua_upvalueindex(2));
-  const upb_handlers *encode_handlers = lua_touserdata(L, lua_upvalueindex(3));
-
+static int lupb_pb_encode(lua_State *L) {
+  const upb_msglayout *layout;
+  const upb_msg *msg = lupb_msg_checkmsg2(L, 1, &layout);
   upb_env env;
-  upb_bufsink *bufsink;
-  upb_bytessink *bytessink;
-  upb_pb_encoder *encoder;
-  upb_visitor *visitor;
-  const char *buf;
-  size_t len;
+  size_t size;
   upb_status status = UPB_STATUS_INIT;
+  char *result;
 
   upb_env_init(&env);
   upb_env_reporterrorsto(&env, &status);
-  bufsink = upb_bufsink_new(&env);
-  bytessink = upb_bufsink_sink(bufsink);
-  encoder = upb_pb_encoder_create(&env, encode_handlers, bytessink);
-  visitor = upb_visitor_create(&env, vp, upb_pb_encoder_input(encoder));
 
-  upb_visitor_visitmsg(visitor, msg);
-  buf = upb_bufsink_getdata(bufsink, &len);
-  lua_pushlstring(L, buf, len);
+  result = upb_encode(msg, (const void*)layout, &env, &size);
 
   /* Free resources before we potentially bail on error. */
   upb_env_uninit(&env);
   lupb_checkstatus(L, &status);
 
+  lua_pushlstring(L, result, size);
   return 1;
 }
-
-static int lupb_pb_makestrtomsgdecoder(lua_State *L) {
-  const upb_msglayout *layout = lupb_msgclass_getlayout(L, 1);
-  const upb_handlers *handlers = lupb_msgclass_getmergehandlers(L, 1);
-  const upb_pbdecodermethod *m;
-
-  upb_pbdecodermethodopts opts;
-  upb_pbdecodermethodopts_init(&opts, handlers);
-
-  m = upb_pbdecodermethod_new(&opts, &m);
-
-  /* Push upvalues for the closure. */
-  lua_pushlightuserdata(L, (void*)layout);
-  lua_pushlightuserdata(L, (void*)m);
-  lua_pushvalue(L, 1);
-
-  /* Upvalue for the closure, only to keep the decodermethod alive. */
-  lupb_refcounted_pushnewrapper(
-      L, upb_pbdecodermethod_upcast(m), LUPB_PBDECODERMETHOD, &m);
-
-  lua_pushcclosure(L, &lupb_pb_strtomessage, 4);
-
-  return 1;  /* The decoder closure. */
-}
-
-static int lupb_pb_makemsgtostrencoder(lua_State *L) {
-  const lupb_msgclass *lmsgclass = lupb_msgclass_check(L, 1);
-  const upb_msgdef *md = lupb_msgclass_getmsgdef(lmsgclass);
-  upb_msgfactory *factory = lupb_msgclass_getfactory(lmsgclass);
-  const upb_handlers *encode_handlers;
-  const upb_visitorplan *vp;
-
-  encode_handlers = upb_pb_encoder_newhandlers(md, &encode_handlers);
-  vp = upb_msgfactory_getvisitorplan(factory, encode_handlers);
-
-  /* Push upvalues for the closure. */
-  lua_pushlightuserdata(L, (void*)lmsgclass);
-  lua_pushlightuserdata(L, (void*)vp);
-  lua_pushlightuserdata(L, (void*)encode_handlers);
-
-  /* Upvalues for the closure, only to keep the other upvalues alive. */
-  lua_pushvalue(L, 1);
-  lupb_refcounted_pushnewrapper(
-      L, upb_handlers_upcast(encode_handlers), LUPB_PBDECODERMETHOD, &encode_handlers);
-
-  lua_pushcclosure(L, &lupb_pb_messagetostr, 5);
-
-  return 1;  /* The decoder closure. */
-}
-
-static const struct luaL_Reg decodermethod_mm[] = {
-  {"__gc", lupb_refcounted_gc},
-  {NULL, NULL}
-};
 
 static const struct luaL_Reg toplevel_m[] = {
-  {"MakeStringToMessageDecoder", lupb_pb_makestrtomsgdecoder},
-  {"MakeMessageToStringEncoder", lupb_pb_makemsgtostrencoder},
+  {"decode", lupb_pb_decode},
+  {"encode", lupb_pb_encode},
   {NULL, NULL}
 };
 
@@ -143,8 +64,6 @@ int luaopen_upb_pb_c(lua_State *L) {
   if (lupb_openlib(L, &module_key, "upb.pb_c", toplevel_m)) {
     return 1;
   }
-
-  lupb_register_type(L, LUPB_PBDECODERMETHOD, NULL, decodermethod_mm);
 
   return 1;
 }

--- a/upb/handlers.h
+++ b/upb/handlers.h
@@ -799,6 +799,34 @@ UPB_INLINE upb_selector_t upb_handlers_getendselector(upb_selector_t start) {
 uint32_t upb_handlers_selectorbaseoffset(const upb_fielddef *f);
 uint32_t upb_handlers_selectorcount(const upb_fielddef *f);
 
+
+/** Message handlers ******************************************************************/
+
+/* These are the handlers used internally by upb_msgfactory_getmergehandlers().
+ * They write scalar data to a known offset from the message pointer.
+ *
+ * These would be trivial for anyone to implement themselves, but it's better
+ * to use these because some JITs will recognize and specialize these instead
+ * of actually calling the function. */
+
+/* Sets a handler for the given primitive field that will write the data at the
+ * given offset.  If hasbit > 0, also sets a hasbit at the given bit offset
+ * (addressing each byte low to high). */
+bool upb_msg_setscalarhandler(upb_handlers *h,
+                              const upb_fielddef *f,
+                              size_t offset,
+                              int32_t hasbit);
+
+/* If the given handler is a msghandlers_primitive field, returns true and sets
+ * *type, *offset and *hasbit.  Otherwise returns false. */
+bool upb_msg_getscalarhandlerdata(const upb_handlers *h,
+                                  upb_selector_t s,
+                                  upb_fieldtype_t *type,
+                                  size_t *offset,
+                                  int32_t *hasbit);
+
+
+
 UPB_END_EXTERN_C
 
 #include "upb/handlers-inl.h"

--- a/upb/msg.h
+++ b/upb/msg.h
@@ -292,32 +292,6 @@ void upb_mapiter_setdone(upb_mapiter *i);
 bool upb_mapiter_isequal(const upb_mapiter *i1, const upb_mapiter *i2);
 
 
-/** Handlers ******************************************************************/
-
-/* These are the handlers used internally by upb_msgfactory_getmergehandlers().
- * They write scalar data to a known offset from the message pointer.
- *
- * These would be trivial for anyone to implement themselves, but it's better
- * to use these because some JITs will recognize and specialize these instead
- * of actually calling the function. */
-
-/* Sets a handler for the given primitive field that will write the data at the
- * given offset.  If hasbit > 0, also sets a hasbit at the given bit offset
- * (addressing each byte low to high). */
-bool upb_msg_setscalarhandler(upb_handlers *h,
-                              const upb_fielddef *f,
-                              size_t offset,
-                              int32_t hasbit);
-
-/* If the given handler is a msghandlers_primitive field, returns true and sets
- * *type, *offset and *hasbit.  Otherwise returns false. */
-bool upb_msg_getscalarhandlerdata(const upb_handlers *h,
-                                  upb_selector_t s,
-                                  upb_fieldtype_t *type,
-                                  size_t *offset,
-                                  int32_t *hasbit);
-
-
 /** Interfaces for generated code *********************************************/
 
 #define UPB_NOT_IN_ONEOF UINT16_MAX

--- a/upb/structs.int.h
+++ b/upb/structs.int.h
@@ -11,7 +11,7 @@ struct upb_array {
   void *data;   /* Each element is element_size. */
   size_t len;   /* Measured in elements. */
   size_t size;  /* Measured in elements. */
-  upb_alloc *alloc;
+  upb_arena *arena;
 };
 
 #endif  /* UPB_STRUCTS_H_ */


### PR DESCRIPTION
upb_msg was trying to be general enough that it could either live in
an arena or be allocated with malloc()/free().  This was too much
complexity for too little benefit.  We should commit to just saying
that upb_msg is arena-only.

I also ripped out the code to glue upb_msg to the existing
handlers-based encoder/decoder.  upb_msg has its own, small, simple
encoder/decoder.  I'm trying to whittle down upb_msg to a small
and simple core.

I updated the Lua extension for these changes.  Lua needs some more
work to properly create arenas per message.  For now I just created
a single global arena.