### PR TITLE
Moved upb_msg parts that depend on def to a separate msgfactory.{c,h}.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,228 @@
+
+cmake_minimum_required (VERSION 3.0)
+cmake_policy(SET CMP0048 NEW)
+project (upb)
+
+# Options we define for users.
+option(UPB_ENABLE_ASAN "Enable address sanitizer." OFF)
+option(UPB_ENABLE_UBSAN "Enable undefined behavior sanitizer." OFF)
+
+# Set default build type.
+if(NOT CMAKE_BUILD_TYPE)
+  message(STATUS "Setting build type to 'RelWithDebInfo' as none was specified.")
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
+      "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel."
+      FORCE)
+endif()
+
+# Check out Git submodules.
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.gitmodules")
+  execute_process (COMMAND git submodule update --init --recursive
+                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
+set(protobuf_BUILD_TESTS OFF CACHE BOOL "enable tests for proto2" FORCE)
+set(protobuf_BUILD_SHARED_LIBS OFF CACHE BOOL "enable shared libs for proto2" FORCE)
+add_subdirectory(third_party/protobuf/cmake)
+
+# When using Ninja, compiler output won't be colorized without this.
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG(-fdiagnostics-color=always SUPPORTS_COLOR_ALWAYS)
+if(SUPPORTS_COLOR_ALWAYS)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
+endif()
+
+# Implement ASAN/UBSAN options
+if(UPB_ENABLE_ASAN)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+  set(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fsanitize=address")
+endif()
+
+if(UPB_ENABLE_UBSAN)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
+  set(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fsanitize=undefined")
+endif()
+
+include_directories(.)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+if(APPLE)
+elseif(UNIX)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--build-id")
+endif()
+
+FIND_PACKAGE(Lua)
+
+if(LUA_FOUND)
+  include_directories(${LUA_INCLUDE_DIR})
+
+  add_library(upb_c SHARED
+    upb/bindings/lua/upb.c
+    upb/bindings/lua/def.c
+    upb/bindings/lua/msg.c
+  )
+  target_link_libraries(upb_c LINK_PRIVATE
+    upbpb_pic
+    upbdef_pic
+    upbhandlers_pic upb_pic )
+
+  add_library(table_c SHARED
+    upb/bindings/lua/upb/table.c
+  )
+  target_link_libraries(table_c LINK_PRIVATE upb_c upb_pic)
+
+  add_library(pb_c SHARED
+    upb/bindings/lua/upb/pb.c
+  )
+  target_link_libraries(pb_c LINK_PRIVATE upb_c upbpb_pic)
+
+  set_target_properties(upb_c
+    PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "lua"
+    PREFIX "")
+  set_target_properties(table_c pb_c
+    PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "lua/upb"
+    PREFIX "")
+
+  add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tools/upbc
+        DEPENDS ${CMAKE_SOURCE_DIR}/tools/upbc
+                ${CMAKE_SOURCE_DIR}/tools/upbc.lua
+                ${CMAKE_SOURCE_DIR}/tools/dump_cinit.lua
+                ${CMAKE_SOURCE_DIR}/tools/make_c_api.lua
+                ${CMAKE_SOURCE_DIR}/upb/bindings/lua/upb.lua
+                ${CMAKE_SOURCE_DIR}/upb/bindings/lua/upb/table.lua
+                ${CMAKE_SOURCE_DIR}/upb/bindings/lua/upb/pb.lua
+                upb_c
+                table_c
+                pb_c
+        COMMAND ${CMAKE_COMMAND} -E copy
+                ${CMAKE_SOURCE_DIR}/tools/upbc
+                ${CMAKE_SOURCE_DIR}/tools/upbc.lua
+                ${CMAKE_SOURCE_DIR}/tools/dump_cinit.lua
+                ${CMAKE_SOURCE_DIR}/tools/make_c_api.lua
+                ${CMAKE_SOURCE_DIR}/upb/bindings/lua/upb.lua
+                ${CMAKE_SOURCE_DIR}/upb/bindings/lua/upb/table.lua
+                ${CMAKE_SOURCE_DIR}/upb/bindings/lua/upb/pb.lua
+                ${CMAKE_CURRENT_BINARY_DIR}/tools)
+  add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lua/upb.lua
+        DEPENDS ${CMAKE_SOURCE_DIR}/upb/bindings/lua/upb.lua
+        COMMAND ${CMAKE_COMMAND} -E copy
+                ${CMAKE_SOURCE_DIR}/upb/bindings/lua/upb.lua
+                ${CMAKE_CURRENT_BINARY_DIR}/lua)
+  add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lua/upb/pb.lua
+        DEPENDS ${CMAKE_SOURCE_DIR}/upb/bindings/lua/upb/table.lua
+                ${CMAKE_SOURCE_DIR}/upb/bindings/lua/upb/pb.lua
+        COMMAND ${CMAKE_COMMAND} -E copy
+                ${CMAKE_SOURCE_DIR}/upb/bindings/lua/upb/table.lua
+                ${CMAKE_SOURCE_DIR}/upb/bindings/lua/upb/pb.lua
+                ${CMAKE_CURRENT_BINARY_DIR}/lua/upb)
+  add_custom_target(
+    upbc ALL
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tools/upbc
+            ${CMAKE_CURRENT_BINARY_DIR}/lua/upb.lua
+            ${CMAKE_CURRENT_BINARY_DIR}/lua/upb/pb.lua
+  )
+
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/conformance.upb.h
+           ${CMAKE_CURRENT_BINARY_DIR}/conformance.upb.c
+    DEPENDS upbc ${CMAKE_CURRENT_SOURCE_DIR}/third_party/protobuf/conformance/conformance.proto
+    COMMAND protoc --include_imports
+        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/protobuf/conformance/conformance.proto
+        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/protobuf/src/google/protobuf/test_messages_proto3.proto
+        -I${CMAKE_CURRENT_SOURCE_DIR}/third_party/protobuf/conformance
+        -I${CMAKE_CURRENT_SOURCE_DIR}/third_party/protobuf/src
+        -o${CMAKE_CURRENT_BINARY_DIR}/conformance.pb &&
+        tools/upbc ${CMAKE_CURRENT_BINARY_DIR}/conformance.pb
+  )
+
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/google/protobuf/descriptor.upb.h
+           ${CMAKE_CURRENT_BINARY_DIR}/google/protobuf/descriptor.upb.c
+    DEPENDS upbc ${CMAKE_CURRENT_SOURCE_DIR}/google/protobuf/descriptor.proto
+    COMMAND protoc
+        ${CMAKE_CURRENT_SOURCE_DIR}/google/protobuf/descriptor.proto
+        -I${CMAKE_CURRENT_SOURCE_DIR}
+        -o${CMAKE_CURRENT_BINARY_DIR}/descriptor.pb &&
+        tools/upbc ${CMAKE_CURRENT_BINARY_DIR}/descriptor.pb
+  )
+
+  add_custom_target(
+    genfiles
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/conformance.upb.h
+            ${CMAKE_CURRENT_BINARY_DIR}/google/protobuf/descriptor.upb.h
+  )
+endif()
+
+set(UPB_SRCS
+    upb/decode.c
+    upb/encode.c
+    upb/msg.c
+    upb/table.c
+    upb/upb.c
+)
+
+set (UPBDEF_SRCS
+    upb/descriptor/descriptor.upbdefs.c
+    upb/descriptor/reader.c
+    upb/def.c
+    upb/msgfactory.c
+    upb/refcounted.c
+)
+
+set(UPBHANDLERS_SRCS
+    upb/sink.c
+    upb/handlers.c
+)
+
+set(UPBPB_SRCS
+  upb/pb/compile_decoder.c
+  upb/pb/decoder.c
+  upb/pb/encoder.c
+  upb/pb/glue.c
+  upb/pb/textprinter.c
+  upb/pb/varint.c
+)
+
+set(UPBJSON_SRCS
+  upb/json/parser.c
+  upb/json/printer.c
+)
+
+add_library(upb ${UPB_SRCS})
+add_library(upbdef ${UPBDEF_SRCS})
+add_library(upbhandlers ${UPBHANDLERS_SRCS})
+add_library(upbpb ${UPBPB_SRCS})
+add_library(upbjson ${UPBJSON_SRCS})
+
+add_library(upb_pic ${UPB_SRCS})
+add_library(upbdef_pic ${UPBDEF_SRCS})
+add_library(upbhandlers_pic ${UPBHANDLERS_SRCS})
+add_library(upbpb_pic ${UPBPB_SRCS})
+add_library(upbjson_pic ${UPBJSON_SRCS})
+
+set_property(TARGET upb_pic PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET upbdef_pic PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET upbhandlers_pic PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET upbpb_pic PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET upbjson_pic PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+add_executable(conformance_upb
+  tests/conformance_upb.c
+  ${CMAKE_CURRENT_BINARY_DIR}/google/protobuf/test_messages_proto3.upb.c
+  ${CMAKE_CURRENT_BINARY_DIR}/google/protobuf/any.upb.c
+  ${CMAKE_CURRENT_BINARY_DIR}/google/protobuf/duration.upb.c
+  ${CMAKE_CURRENT_BINARY_DIR}/google/protobuf/field_mask.upb.c
+  ${CMAKE_CURRENT_BINARY_DIR}/google/protobuf/struct.upb.c
+  ${CMAKE_CURRENT_BINARY_DIR}/google/protobuf/test_messages_proto3.upb.c
+  ${CMAKE_CURRENT_BINARY_DIR}/google/protobuf/timestamp.upb.c
+  ${CMAKE_CURRENT_BINARY_DIR}/google/protobuf/wrappers.upb.c
+  ${CMAKE_CURRENT_BINARY_DIR}/conformance.upb.c
+  )
+target_link_libraries(conformance_upb LINK_PRIVATE
+  upb
+)

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ upb_SRCS = \
   upb/encode.c \
   upb/handlers.c \
   upb/msg.c \
+  upb/msgfactory.c \
   upb/refcounted.c \
   upb/sink.c \
   upb/table.c \

--- a/google/protobuf/descriptor.upb.c
+++ b/google/protobuf/descriptor.upb.c
@@ -18,15 +18,15 @@ struct google_protobuf_FileDescriptorSet {
   upb_array* file;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_FileDescriptorSet_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_FileDescriptorSet_submsgs[1] = {
   &google_protobuf_FileDescriptorProto_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_FileDescriptorSet__fields[1] = {
+static const upb_msglayout_field google_protobuf_FileDescriptorSet__fields[1] = {
   {1, offsetof(google_protobuf_FileDescriptorSet, file), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_FileDescriptorSet_msginit = {
+const upb_msglayout google_protobuf_FileDescriptorSet_msginit = {
   &google_protobuf_FileDescriptorSet_submsgs[0],
   &google_protobuf_FileDescriptorSet__fields[0],
   NULL,
@@ -71,7 +71,7 @@ struct google_protobuf_FileDescriptorProto {
   upb_array* weak_dependency;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_FileDescriptorProto_submsgs[6] = {
+static const upb_msglayout *const google_protobuf_FileDescriptorProto_submsgs[6] = {
   &google_protobuf_DescriptorProto_msginit,
   &google_protobuf_EnumDescriptorProto_msginit,
   &google_protobuf_FieldDescriptorProto_msginit,
@@ -80,7 +80,7 @@ static const upb_msglayout_msginit_v1 *const google_protobuf_FileDescriptorProto
   &google_protobuf_SourceCodeInfo_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_FileDescriptorProto__fields[12] = {
+static const upb_msglayout_field google_protobuf_FileDescriptorProto__fields[12] = {
   {1, offsetof(google_protobuf_FileDescriptorProto, name), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
   {2, offsetof(google_protobuf_FileDescriptorProto, package), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
   {3, offsetof(google_protobuf_FileDescriptorProto, dependency), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 3},
@@ -95,7 +95,7 @@ static const upb_msglayout_fieldinit_v1 google_protobuf_FileDescriptorProto__fie
   {12, offsetof(google_protobuf_FileDescriptorProto, syntax), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_FileDescriptorProto_msginit = {
+const upb_msglayout google_protobuf_FileDescriptorProto_msginit = {
   &google_protobuf_FileDescriptorProto_submsgs[0],
   &google_protobuf_FileDescriptorProto__fields[0],
   NULL,
@@ -204,7 +204,7 @@ struct google_protobuf_DescriptorProto {
   upb_array* reserved_name;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_DescriptorProto_submsgs[8] = {
+static const upb_msglayout *const google_protobuf_DescriptorProto_submsgs[8] = {
   &google_protobuf_DescriptorProto_msginit,
   &google_protobuf_DescriptorProto_ExtensionRange_msginit,
   &google_protobuf_DescriptorProto_ReservedRange_msginit,
@@ -214,7 +214,7 @@ static const upb_msglayout_msginit_v1 *const google_protobuf_DescriptorProto_sub
   &google_protobuf_OneofDescriptorProto_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_DescriptorProto__fields[10] = {
+static const upb_msglayout_field google_protobuf_DescriptorProto__fields[10] = {
   {1, offsetof(google_protobuf_DescriptorProto, name), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
   {2, offsetof(google_protobuf_DescriptorProto, field), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 4, 11, 3},
   {3, offsetof(google_protobuf_DescriptorProto, nested_type), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
@@ -227,7 +227,7 @@ static const upb_msglayout_fieldinit_v1 google_protobuf_DescriptorProto__fields[
   {10, offsetof(google_protobuf_DescriptorProto, reserved_name), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 3},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_DescriptorProto_msginit = {
+const upb_msglayout google_protobuf_DescriptorProto_msginit = {
   &google_protobuf_DescriptorProto_submsgs[0],
   &google_protobuf_DescriptorProto__fields[0],
   NULL,
@@ -317,17 +317,17 @@ struct google_protobuf_DescriptorProto_ExtensionRange {
   google_protobuf_ExtensionRangeOptions* options;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_DescriptorProto_ExtensionRange_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_DescriptorProto_ExtensionRange_submsgs[1] = {
   &google_protobuf_ExtensionRangeOptions_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_DescriptorProto_ExtensionRange__fields[3] = {
+static const upb_msglayout_field google_protobuf_DescriptorProto_ExtensionRange__fields[3] = {
   {1, offsetof(google_protobuf_DescriptorProto_ExtensionRange, start), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
   {2, offsetof(google_protobuf_DescriptorProto_ExtensionRange, end), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
   {3, offsetof(google_protobuf_DescriptorProto_ExtensionRange, options), 2, UPB_NOT_IN_ONEOF, 0, 11, 1},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_DescriptorProto_ExtensionRange_msginit = {
+const upb_msglayout google_protobuf_DescriptorProto_ExtensionRange_msginit = {
   &google_protobuf_DescriptorProto_ExtensionRange_submsgs[0],
   &google_protobuf_DescriptorProto_ExtensionRange__fields[0],
   NULL,
@@ -374,12 +374,12 @@ struct google_protobuf_DescriptorProto_ReservedRange {
   int32_t end;
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_DescriptorProto_ReservedRange__fields[2] = {
+static const upb_msglayout_field google_protobuf_DescriptorProto_ReservedRange__fields[2] = {
   {1, offsetof(google_protobuf_DescriptorProto_ReservedRange, start), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
   {2, offsetof(google_protobuf_DescriptorProto_ReservedRange, end), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_DescriptorProto_ReservedRange_msginit = {
+const upb_msglayout google_protobuf_DescriptorProto_ReservedRange_msginit = {
   NULL,
   &google_protobuf_DescriptorProto_ReservedRange__fields[0],
   NULL,
@@ -419,15 +419,15 @@ struct google_protobuf_ExtensionRangeOptions {
   upb_array* uninterpreted_option;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_ExtensionRangeOptions_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_ExtensionRangeOptions_submsgs[1] = {
   &google_protobuf_UninterpretedOption_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_ExtensionRangeOptions__fields[1] = {
+static const upb_msglayout_field google_protobuf_ExtensionRangeOptions__fields[1] = {
   {999, offsetof(google_protobuf_ExtensionRangeOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_ExtensionRangeOptions_msginit = {
+const upb_msglayout google_protobuf_ExtensionRangeOptions_msginit = {
   &google_protobuf_ExtensionRangeOptions_submsgs[0],
   &google_protobuf_ExtensionRangeOptions__fields[0],
   NULL,
@@ -470,11 +470,11 @@ struct google_protobuf_FieldDescriptorProto {
   google_protobuf_FieldOptions* options;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_FieldDescriptorProto_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_FieldDescriptorProto_submsgs[1] = {
   &google_protobuf_FieldOptions_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_FieldDescriptorProto__fields[10] = {
+static const upb_msglayout_field google_protobuf_FieldDescriptorProto__fields[10] = {
   {1, offsetof(google_protobuf_FieldDescriptorProto, name), 4, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
   {2, offsetof(google_protobuf_FieldDescriptorProto, extendee), 5, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
   {3, offsetof(google_protobuf_FieldDescriptorProto, number), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
@@ -487,7 +487,7 @@ static const upb_msglayout_fieldinit_v1 google_protobuf_FieldDescriptorProto__fi
   {10, offsetof(google_protobuf_FieldDescriptorProto, json_name), 8, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_FieldDescriptorProto_msginit = {
+const upb_msglayout google_protobuf_FieldDescriptorProto_msginit = {
   &google_protobuf_FieldDescriptorProto_submsgs[0],
   &google_protobuf_FieldDescriptorProto__fields[0],
   NULL,
@@ -576,16 +576,16 @@ struct google_protobuf_OneofDescriptorProto {
   google_protobuf_OneofOptions* options;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_OneofDescriptorProto_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_OneofDescriptorProto_submsgs[1] = {
   &google_protobuf_OneofOptions_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_OneofDescriptorProto__fields[2] = {
+static const upb_msglayout_field google_protobuf_OneofDescriptorProto__fields[2] = {
   {1, offsetof(google_protobuf_OneofDescriptorProto, name), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
   {2, offsetof(google_protobuf_OneofDescriptorProto, options), 1, UPB_NOT_IN_ONEOF, 0, 11, 1},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_OneofDescriptorProto_msginit = {
+const upb_msglayout google_protobuf_OneofDescriptorProto_msginit = {
   &google_protobuf_OneofDescriptorProto_submsgs[0],
   &google_protobuf_OneofDescriptorProto__fields[0],
   NULL,
@@ -629,13 +629,13 @@ struct google_protobuf_EnumDescriptorProto {
   upb_array* reserved_name;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_EnumDescriptorProto_submsgs[3] = {
+static const upb_msglayout *const google_protobuf_EnumDescriptorProto_submsgs[3] = {
   &google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit,
   &google_protobuf_EnumOptions_msginit,
   &google_protobuf_EnumValueDescriptorProto_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_EnumDescriptorProto__fields[5] = {
+static const upb_msglayout_field google_protobuf_EnumDescriptorProto__fields[5] = {
   {1, offsetof(google_protobuf_EnumDescriptorProto, name), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
   {2, offsetof(google_protobuf_EnumDescriptorProto, value), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 2, 11, 3},
   {3, offsetof(google_protobuf_EnumDescriptorProto, options), 1, UPB_NOT_IN_ONEOF, 1, 11, 1},
@@ -643,7 +643,7 @@ static const upb_msglayout_fieldinit_v1 google_protobuf_EnumDescriptorProto__fie
   {5, offsetof(google_protobuf_EnumDescriptorProto, reserved_name), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 3},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_EnumDescriptorProto_msginit = {
+const upb_msglayout google_protobuf_EnumDescriptorProto_msginit = {
   &google_protobuf_EnumDescriptorProto_submsgs[0],
   &google_protobuf_EnumDescriptorProto__fields[0],
   NULL,
@@ -702,12 +702,12 @@ struct google_protobuf_EnumDescriptorProto_EnumReservedRange {
   int32_t end;
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_EnumDescriptorProto_EnumReservedRange__fields[2] = {
+static const upb_msglayout_field google_protobuf_EnumDescriptorProto_EnumReservedRange__fields[2] = {
   {1, offsetof(google_protobuf_EnumDescriptorProto_EnumReservedRange, start), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
   {2, offsetof(google_protobuf_EnumDescriptorProto_EnumReservedRange, end), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit = {
+const upb_msglayout google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit = {
   NULL,
   &google_protobuf_EnumDescriptorProto_EnumReservedRange__fields[0],
   NULL,
@@ -749,17 +749,17 @@ struct google_protobuf_EnumValueDescriptorProto {
   google_protobuf_EnumValueOptions* options;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_EnumValueDescriptorProto_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_EnumValueDescriptorProto_submsgs[1] = {
   &google_protobuf_EnumValueOptions_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_EnumValueDescriptorProto__fields[3] = {
+static const upb_msglayout_field google_protobuf_EnumValueDescriptorProto__fields[3] = {
   {1, offsetof(google_protobuf_EnumValueDescriptorProto, name), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
   {2, offsetof(google_protobuf_EnumValueDescriptorProto, number), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
   {3, offsetof(google_protobuf_EnumValueDescriptorProto, options), 2, UPB_NOT_IN_ONEOF, 0, 11, 1},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_EnumValueDescriptorProto_msginit = {
+const upb_msglayout google_protobuf_EnumValueDescriptorProto_msginit = {
   &google_protobuf_EnumValueDescriptorProto_submsgs[0],
   &google_protobuf_EnumValueDescriptorProto__fields[0],
   NULL,
@@ -807,18 +807,18 @@ struct google_protobuf_ServiceDescriptorProto {
   upb_array* method;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_ServiceDescriptorProto_submsgs[2] = {
+static const upb_msglayout *const google_protobuf_ServiceDescriptorProto_submsgs[2] = {
   &google_protobuf_MethodDescriptorProto_msginit,
   &google_protobuf_ServiceOptions_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_ServiceDescriptorProto__fields[3] = {
+static const upb_msglayout_field google_protobuf_ServiceDescriptorProto__fields[3] = {
   {1, offsetof(google_protobuf_ServiceDescriptorProto, name), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
   {2, offsetof(google_protobuf_ServiceDescriptorProto, method), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
   {3, offsetof(google_protobuf_ServiceDescriptorProto, options), 1, UPB_NOT_IN_ONEOF, 1, 11, 1},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_ServiceDescriptorProto_msginit = {
+const upb_msglayout google_protobuf_ServiceDescriptorProto_msginit = {
   &google_protobuf_ServiceDescriptorProto_submsgs[0],
   &google_protobuf_ServiceDescriptorProto__fields[0],
   NULL,
@@ -869,11 +869,11 @@ struct google_protobuf_MethodDescriptorProto {
   google_protobuf_MethodOptions* options;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_MethodDescriptorProto_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_MethodDescriptorProto_submsgs[1] = {
   &google_protobuf_MethodOptions_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_MethodDescriptorProto__fields[6] = {
+static const upb_msglayout_field google_protobuf_MethodDescriptorProto__fields[6] = {
   {1, offsetof(google_protobuf_MethodDescriptorProto, name), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
   {2, offsetof(google_protobuf_MethodDescriptorProto, input_type), 3, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
   {3, offsetof(google_protobuf_MethodDescriptorProto, output_type), 4, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
@@ -882,7 +882,7 @@ static const upb_msglayout_fieldinit_v1 google_protobuf_MethodDescriptorProto__f
   {6, offsetof(google_protobuf_MethodDescriptorProto, server_streaming), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_MethodDescriptorProto_msginit = {
+const upb_msglayout google_protobuf_MethodDescriptorProto_msginit = {
   &google_protobuf_MethodDescriptorProto_submsgs[0],
   &google_protobuf_MethodDescriptorProto__fields[0],
   NULL,
@@ -964,11 +964,11 @@ struct google_protobuf_FileOptions {
   upb_array* uninterpreted_option;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_FileOptions_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_FileOptions_submsgs[1] = {
   &google_protobuf_UninterpretedOption_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_FileOptions__fields[19] = {
+static const upb_msglayout_field google_protobuf_FileOptions__fields[19] = {
   {1, offsetof(google_protobuf_FileOptions, java_package), 10, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
   {8, offsetof(google_protobuf_FileOptions, java_outer_classname), 11, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
   {9, offsetof(google_protobuf_FileOptions, optimize_for), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 14, 1},
@@ -990,7 +990,7 @@ static const upb_msglayout_fieldinit_v1 google_protobuf_FileOptions__fields[19] 
   {999, offsetof(google_protobuf_FileOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_FileOptions_msginit = {
+const upb_msglayout google_protobuf_FileOptions_msginit = {
   &google_protobuf_FileOptions_submsgs[0],
   &google_protobuf_FileOptions__fields[0],
   NULL,
@@ -1136,11 +1136,11 @@ struct google_protobuf_MessageOptions {
   upb_array* uninterpreted_option;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_MessageOptions_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_MessageOptions_submsgs[1] = {
   &google_protobuf_UninterpretedOption_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_MessageOptions__fields[5] = {
+static const upb_msglayout_field google_protobuf_MessageOptions__fields[5] = {
   {1, offsetof(google_protobuf_MessageOptions, message_set_wire_format), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
   {2, offsetof(google_protobuf_MessageOptions, no_standard_descriptor_accessor), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
   {3, offsetof(google_protobuf_MessageOptions, deprecated), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
@@ -1148,7 +1148,7 @@ static const upb_msglayout_fieldinit_v1 google_protobuf_MessageOptions__fields[5
   {999, offsetof(google_protobuf_MessageOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_MessageOptions_msginit = {
+const upb_msglayout google_protobuf_MessageOptions_msginit = {
   &google_protobuf_MessageOptions_submsgs[0],
   &google_protobuf_MessageOptions__fields[0],
   NULL,
@@ -1212,11 +1212,11 @@ struct google_protobuf_FieldOptions {
   upb_array* uninterpreted_option;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_FieldOptions_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_FieldOptions_submsgs[1] = {
   &google_protobuf_UninterpretedOption_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_FieldOptions__fields[7] = {
+static const upb_msglayout_field google_protobuf_FieldOptions__fields[7] = {
   {1, offsetof(google_protobuf_FieldOptions, ctype), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 14, 1},
   {2, offsetof(google_protobuf_FieldOptions, packed), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
   {3, offsetof(google_protobuf_FieldOptions, deprecated), 3, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
@@ -1226,7 +1226,7 @@ static const upb_msglayout_fieldinit_v1 google_protobuf_FieldOptions__fields[7] 
   {999, offsetof(google_protobuf_FieldOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_FieldOptions_msginit = {
+const upb_msglayout google_protobuf_FieldOptions_msginit = {
   &google_protobuf_FieldOptions_submsgs[0],
   &google_protobuf_FieldOptions__fields[0],
   NULL,
@@ -1296,15 +1296,15 @@ struct google_protobuf_OneofOptions {
   upb_array* uninterpreted_option;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_OneofOptions_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_OneofOptions_submsgs[1] = {
   &google_protobuf_UninterpretedOption_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_OneofOptions__fields[1] = {
+static const upb_msglayout_field google_protobuf_OneofOptions__fields[1] = {
   {999, offsetof(google_protobuf_OneofOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_OneofOptions_msginit = {
+const upb_msglayout google_protobuf_OneofOptions_msginit = {
   &google_protobuf_OneofOptions_submsgs[0],
   &google_protobuf_OneofOptions__fields[0],
   NULL,
@@ -1340,17 +1340,17 @@ struct google_protobuf_EnumOptions {
   upb_array* uninterpreted_option;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_EnumOptions_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_EnumOptions_submsgs[1] = {
   &google_protobuf_UninterpretedOption_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_EnumOptions__fields[3] = {
+static const upb_msglayout_field google_protobuf_EnumOptions__fields[3] = {
   {2, offsetof(google_protobuf_EnumOptions, allow_alias), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
   {3, offsetof(google_protobuf_EnumOptions, deprecated), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
   {999, offsetof(google_protobuf_EnumOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_EnumOptions_msginit = {
+const upb_msglayout google_protobuf_EnumOptions_msginit = {
   &google_protobuf_EnumOptions_submsgs[0],
   &google_protobuf_EnumOptions__fields[0],
   NULL,
@@ -1397,16 +1397,16 @@ struct google_protobuf_EnumValueOptions {
   upb_array* uninterpreted_option;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_EnumValueOptions_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_EnumValueOptions_submsgs[1] = {
   &google_protobuf_UninterpretedOption_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_EnumValueOptions__fields[2] = {
+static const upb_msglayout_field google_protobuf_EnumValueOptions__fields[2] = {
   {1, offsetof(google_protobuf_EnumValueOptions, deprecated), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
   {999, offsetof(google_protobuf_EnumValueOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_EnumValueOptions_msginit = {
+const upb_msglayout google_protobuf_EnumValueOptions_msginit = {
   &google_protobuf_EnumValueOptions_submsgs[0],
   &google_protobuf_EnumValueOptions__fields[0],
   NULL,
@@ -1447,16 +1447,16 @@ struct google_protobuf_ServiceOptions {
   upb_array* uninterpreted_option;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_ServiceOptions_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_ServiceOptions_submsgs[1] = {
   &google_protobuf_UninterpretedOption_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_ServiceOptions__fields[2] = {
+static const upb_msglayout_field google_protobuf_ServiceOptions__fields[2] = {
   {33, offsetof(google_protobuf_ServiceOptions, deprecated), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
   {999, offsetof(google_protobuf_ServiceOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_ServiceOptions_msginit = {
+const upb_msglayout google_protobuf_ServiceOptions_msginit = {
   &google_protobuf_ServiceOptions_submsgs[0],
   &google_protobuf_ServiceOptions__fields[0],
   NULL,
@@ -1498,17 +1498,17 @@ struct google_protobuf_MethodOptions {
   upb_array* uninterpreted_option;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_MethodOptions_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_MethodOptions_submsgs[1] = {
   &google_protobuf_UninterpretedOption_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_MethodOptions__fields[3] = {
+static const upb_msglayout_field google_protobuf_MethodOptions__fields[3] = {
   {33, offsetof(google_protobuf_MethodOptions, deprecated), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
   {34, offsetof(google_protobuf_MethodOptions, idempotency_level), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 14, 1},
   {999, offsetof(google_protobuf_MethodOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_MethodOptions_msginit = {
+const upb_msglayout google_protobuf_MethodOptions_msginit = {
   &google_protobuf_MethodOptions_submsgs[0],
   &google_protobuf_MethodOptions__fields[0],
   NULL,
@@ -1560,11 +1560,11 @@ struct google_protobuf_UninterpretedOption {
   upb_array* name;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_UninterpretedOption_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_UninterpretedOption_submsgs[1] = {
   &google_protobuf_UninterpretedOption_NamePart_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_UninterpretedOption__fields[7] = {
+static const upb_msglayout_field google_protobuf_UninterpretedOption__fields[7] = {
   {2, offsetof(google_protobuf_UninterpretedOption, name), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
   {3, offsetof(google_protobuf_UninterpretedOption, identifier_value), 3, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
   {4, offsetof(google_protobuf_UninterpretedOption, positive_int_value), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 4, 1},
@@ -1574,7 +1574,7 @@ static const upb_msglayout_fieldinit_v1 google_protobuf_UninterpretedOption__fie
   {8, offsetof(google_protobuf_UninterpretedOption, aggregate_value), 5, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_UninterpretedOption_msginit = {
+const upb_msglayout google_protobuf_UninterpretedOption_msginit = {
   &google_protobuf_UninterpretedOption_submsgs[0],
   &google_protobuf_UninterpretedOption__fields[0],
   NULL,
@@ -1645,12 +1645,12 @@ struct google_protobuf_UninterpretedOption_NamePart {
   upb_stringview name_part;
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_UninterpretedOption_NamePart__fields[2] = {
+static const upb_msglayout_field google_protobuf_UninterpretedOption_NamePart__fields[2] = {
   {1, offsetof(google_protobuf_UninterpretedOption_NamePart, name_part), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 2},
   {2, offsetof(google_protobuf_UninterpretedOption_NamePart, is_extension), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 2},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_UninterpretedOption_NamePart_msginit = {
+const upb_msglayout google_protobuf_UninterpretedOption_NamePart_msginit = {
   NULL,
   &google_protobuf_UninterpretedOption_NamePart__fields[0],
   NULL,
@@ -1690,15 +1690,15 @@ struct google_protobuf_SourceCodeInfo {
   upb_array* location;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_SourceCodeInfo_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_SourceCodeInfo_submsgs[1] = {
   &google_protobuf_SourceCodeInfo_Location_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_SourceCodeInfo__fields[1] = {
+static const upb_msglayout_field google_protobuf_SourceCodeInfo__fields[1] = {
   {1, offsetof(google_protobuf_SourceCodeInfo, location), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_SourceCodeInfo_msginit = {
+const upb_msglayout google_protobuf_SourceCodeInfo_msginit = {
   &google_protobuf_SourceCodeInfo_submsgs[0],
   &google_protobuf_SourceCodeInfo__fields[0],
   NULL,
@@ -1736,7 +1736,7 @@ struct google_protobuf_SourceCodeInfo_Location {
   upb_array* leading_detached_comments;
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_SourceCodeInfo_Location__fields[5] = {
+static const upb_msglayout_field google_protobuf_SourceCodeInfo_Location__fields[5] = {
   {1, offsetof(google_protobuf_SourceCodeInfo_Location, path), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 3},
   {2, offsetof(google_protobuf_SourceCodeInfo_Location, span), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 3},
   {3, offsetof(google_protobuf_SourceCodeInfo_Location, leading_comments), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
@@ -1744,7 +1744,7 @@ static const upb_msglayout_fieldinit_v1 google_protobuf_SourceCodeInfo_Location_
   {6, offsetof(google_protobuf_SourceCodeInfo_Location, leading_detached_comments), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 3},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_SourceCodeInfo_Location_msginit = {
+const upb_msglayout google_protobuf_SourceCodeInfo_Location_msginit = {
   NULL,
   &google_protobuf_SourceCodeInfo_Location__fields[0],
   NULL,
@@ -1802,15 +1802,15 @@ struct google_protobuf_GeneratedCodeInfo {
   upb_array* annotation;
 };
 
-static const upb_msglayout_msginit_v1 *const google_protobuf_GeneratedCodeInfo_submsgs[1] = {
+static const upb_msglayout *const google_protobuf_GeneratedCodeInfo_submsgs[1] = {
   &google_protobuf_GeneratedCodeInfo_Annotation_msginit,
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_GeneratedCodeInfo__fields[1] = {
+static const upb_msglayout_field google_protobuf_GeneratedCodeInfo__fields[1] = {
   {1, offsetof(google_protobuf_GeneratedCodeInfo, annotation), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_GeneratedCodeInfo_msginit = {
+const upb_msglayout google_protobuf_GeneratedCodeInfo_msginit = {
   &google_protobuf_GeneratedCodeInfo_submsgs[0],
   &google_protobuf_GeneratedCodeInfo__fields[0],
   NULL,
@@ -1847,14 +1847,14 @@ struct google_protobuf_GeneratedCodeInfo_Annotation {
   upb_array* path;
 };
 
-static const upb_msglayout_fieldinit_v1 google_protobuf_GeneratedCodeInfo_Annotation__fields[4] = {
+static const upb_msglayout_field google_protobuf_GeneratedCodeInfo_Annotation__fields[4] = {
   {1, offsetof(google_protobuf_GeneratedCodeInfo_Annotation, path), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 3},
   {2, offsetof(google_protobuf_GeneratedCodeInfo_Annotation, source_file), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
   {3, offsetof(google_protobuf_GeneratedCodeInfo_Annotation, begin), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
   {4, offsetof(google_protobuf_GeneratedCodeInfo_Annotation, end), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
 };
 
-const upb_msglayout_msginit_v1 google_protobuf_GeneratedCodeInfo_Annotation_msginit = {
+const upb_msglayout google_protobuf_GeneratedCodeInfo_Annotation_msginit = {
   NULL,
   &google_protobuf_GeneratedCodeInfo_Annotation__fields[0],
   NULL,

--- a/google/protobuf/descriptor.upb.h
+++ b/google/protobuf/descriptor.upb.h
@@ -121,7 +121,7 @@ typedef enum {
 } google_protobuf_MethodOptions_IdempotencyLevel;
 
 /* google_protobuf_FileDescriptorSet */
-extern const upb_msglayout_msginit_v1 google_protobuf_FileDescriptorSet_msginit;
+extern const upb_msglayout google_protobuf_FileDescriptorSet_msginit;
 google_protobuf_FileDescriptorSet *google_protobuf_FileDescriptorSet_new(upb_env *env);
 google_protobuf_FileDescriptorSet *google_protobuf_FileDescriptorSet_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_FileDescriptorSet_serialize(google_protobuf_FileDescriptorSet *msg, upb_env *env, size_t *len);
@@ -135,7 +135,7 @@ void google_protobuf_FileDescriptorSet_set_file(google_protobuf_FileDescriptorSe
 
 
 /* google_protobuf_FileDescriptorProto */
-extern const upb_msglayout_msginit_v1 google_protobuf_FileDescriptorProto_msginit;
+extern const upb_msglayout google_protobuf_FileDescriptorProto_msginit;
 google_protobuf_FileDescriptorProto *google_protobuf_FileDescriptorProto_new(upb_env *env);
 google_protobuf_FileDescriptorProto *google_protobuf_FileDescriptorProto_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_FileDescriptorProto_serialize(google_protobuf_FileDescriptorProto *msg, upb_env *env, size_t *len);
@@ -171,7 +171,7 @@ void google_protobuf_FileDescriptorProto_set_syntax(google_protobuf_FileDescript
 
 
 /* google_protobuf_DescriptorProto */
-extern const upb_msglayout_msginit_v1 google_protobuf_DescriptorProto_msginit;
+extern const upb_msglayout google_protobuf_DescriptorProto_msginit;
 google_protobuf_DescriptorProto *google_protobuf_DescriptorProto_new(upb_env *env);
 google_protobuf_DescriptorProto *google_protobuf_DescriptorProto_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_DescriptorProto_serialize(google_protobuf_DescriptorProto *msg, upb_env *env, size_t *len);
@@ -203,7 +203,7 @@ void google_protobuf_DescriptorProto_set_reserved_name(google_protobuf_Descripto
 
 
 /* google_protobuf_DescriptorProto_ExtensionRange */
-extern const upb_msglayout_msginit_v1 google_protobuf_DescriptorProto_ExtensionRange_msginit;
+extern const upb_msglayout google_protobuf_DescriptorProto_ExtensionRange_msginit;
 google_protobuf_DescriptorProto_ExtensionRange *google_protobuf_DescriptorProto_ExtensionRange_new(upb_env *env);
 google_protobuf_DescriptorProto_ExtensionRange *google_protobuf_DescriptorProto_ExtensionRange_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_DescriptorProto_ExtensionRange_serialize(google_protobuf_DescriptorProto_ExtensionRange *msg, upb_env *env, size_t *len);
@@ -221,7 +221,7 @@ void google_protobuf_DescriptorProto_ExtensionRange_set_options(google_protobuf_
 
 
 /* google_protobuf_DescriptorProto_ReservedRange */
-extern const upb_msglayout_msginit_v1 google_protobuf_DescriptorProto_ReservedRange_msginit;
+extern const upb_msglayout google_protobuf_DescriptorProto_ReservedRange_msginit;
 google_protobuf_DescriptorProto_ReservedRange *google_protobuf_DescriptorProto_ReservedRange_new(upb_env *env);
 google_protobuf_DescriptorProto_ReservedRange *google_protobuf_DescriptorProto_ReservedRange_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_DescriptorProto_ReservedRange_serialize(google_protobuf_DescriptorProto_ReservedRange *msg, upb_env *env, size_t *len);
@@ -237,7 +237,7 @@ void google_protobuf_DescriptorProto_ReservedRange_set_end(google_protobuf_Descr
 
 
 /* google_protobuf_ExtensionRangeOptions */
-extern const upb_msglayout_msginit_v1 google_protobuf_ExtensionRangeOptions_msginit;
+extern const upb_msglayout google_protobuf_ExtensionRangeOptions_msginit;
 google_protobuf_ExtensionRangeOptions *google_protobuf_ExtensionRangeOptions_new(upb_env *env);
 google_protobuf_ExtensionRangeOptions *google_protobuf_ExtensionRangeOptions_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_ExtensionRangeOptions_serialize(google_protobuf_ExtensionRangeOptions *msg, upb_env *env, size_t *len);
@@ -251,7 +251,7 @@ void google_protobuf_ExtensionRangeOptions_set_uninterpreted_option(google_proto
 
 
 /* google_protobuf_FieldDescriptorProto */
-extern const upb_msglayout_msginit_v1 google_protobuf_FieldDescriptorProto_msginit;
+extern const upb_msglayout google_protobuf_FieldDescriptorProto_msginit;
 google_protobuf_FieldDescriptorProto *google_protobuf_FieldDescriptorProto_new(upb_env *env);
 google_protobuf_FieldDescriptorProto *google_protobuf_FieldDescriptorProto_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_FieldDescriptorProto_serialize(google_protobuf_FieldDescriptorProto *msg, upb_env *env, size_t *len);
@@ -283,7 +283,7 @@ void google_protobuf_FieldDescriptorProto_set_json_name(google_protobuf_FieldDes
 
 
 /* google_protobuf_OneofDescriptorProto */
-extern const upb_msglayout_msginit_v1 google_protobuf_OneofDescriptorProto_msginit;
+extern const upb_msglayout google_protobuf_OneofDescriptorProto_msginit;
 google_protobuf_OneofDescriptorProto *google_protobuf_OneofDescriptorProto_new(upb_env *env);
 google_protobuf_OneofDescriptorProto *google_protobuf_OneofDescriptorProto_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_OneofDescriptorProto_serialize(google_protobuf_OneofDescriptorProto *msg, upb_env *env, size_t *len);
@@ -299,7 +299,7 @@ void google_protobuf_OneofDescriptorProto_set_options(google_protobuf_OneofDescr
 
 
 /* google_protobuf_EnumDescriptorProto */
-extern const upb_msglayout_msginit_v1 google_protobuf_EnumDescriptorProto_msginit;
+extern const upb_msglayout google_protobuf_EnumDescriptorProto_msginit;
 google_protobuf_EnumDescriptorProto *google_protobuf_EnumDescriptorProto_new(upb_env *env);
 google_protobuf_EnumDescriptorProto *google_protobuf_EnumDescriptorProto_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_EnumDescriptorProto_serialize(google_protobuf_EnumDescriptorProto *msg, upb_env *env, size_t *len);
@@ -321,7 +321,7 @@ void google_protobuf_EnumDescriptorProto_set_reserved_name(google_protobuf_EnumD
 
 
 /* google_protobuf_EnumDescriptorProto_EnumReservedRange */
-extern const upb_msglayout_msginit_v1 google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit;
+extern const upb_msglayout google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit;
 google_protobuf_EnumDescriptorProto_EnumReservedRange *google_protobuf_EnumDescriptorProto_EnumReservedRange_new(upb_env *env);
 google_protobuf_EnumDescriptorProto_EnumReservedRange *google_protobuf_EnumDescriptorProto_EnumReservedRange_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_EnumDescriptorProto_EnumReservedRange_serialize(google_protobuf_EnumDescriptorProto_EnumReservedRange *msg, upb_env *env, size_t *len);
@@ -337,7 +337,7 @@ void google_protobuf_EnumDescriptorProto_EnumReservedRange_set_end(google_protob
 
 
 /* google_protobuf_EnumValueDescriptorProto */
-extern const upb_msglayout_msginit_v1 google_protobuf_EnumValueDescriptorProto_msginit;
+extern const upb_msglayout google_protobuf_EnumValueDescriptorProto_msginit;
 google_protobuf_EnumValueDescriptorProto *google_protobuf_EnumValueDescriptorProto_new(upb_env *env);
 google_protobuf_EnumValueDescriptorProto *google_protobuf_EnumValueDescriptorProto_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_EnumValueDescriptorProto_serialize(google_protobuf_EnumValueDescriptorProto *msg, upb_env *env, size_t *len);
@@ -355,7 +355,7 @@ void google_protobuf_EnumValueDescriptorProto_set_options(google_protobuf_EnumVa
 
 
 /* google_protobuf_ServiceDescriptorProto */
-extern const upb_msglayout_msginit_v1 google_protobuf_ServiceDescriptorProto_msginit;
+extern const upb_msglayout google_protobuf_ServiceDescriptorProto_msginit;
 google_protobuf_ServiceDescriptorProto *google_protobuf_ServiceDescriptorProto_new(upb_env *env);
 google_protobuf_ServiceDescriptorProto *google_protobuf_ServiceDescriptorProto_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_ServiceDescriptorProto_serialize(google_protobuf_ServiceDescriptorProto *msg, upb_env *env, size_t *len);
@@ -373,7 +373,7 @@ void google_protobuf_ServiceDescriptorProto_set_options(google_protobuf_ServiceD
 
 
 /* google_protobuf_MethodDescriptorProto */
-extern const upb_msglayout_msginit_v1 google_protobuf_MethodDescriptorProto_msginit;
+extern const upb_msglayout google_protobuf_MethodDescriptorProto_msginit;
 google_protobuf_MethodDescriptorProto *google_protobuf_MethodDescriptorProto_new(upb_env *env);
 google_protobuf_MethodDescriptorProto *google_protobuf_MethodDescriptorProto_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_MethodDescriptorProto_serialize(google_protobuf_MethodDescriptorProto *msg, upb_env *env, size_t *len);
@@ -397,7 +397,7 @@ void google_protobuf_MethodDescriptorProto_set_server_streaming(google_protobuf_
 
 
 /* google_protobuf_FileOptions */
-extern const upb_msglayout_msginit_v1 google_protobuf_FileOptions_msginit;
+extern const upb_msglayout google_protobuf_FileOptions_msginit;
 google_protobuf_FileOptions *google_protobuf_FileOptions_new(upb_env *env);
 google_protobuf_FileOptions *google_protobuf_FileOptions_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_FileOptions_serialize(google_protobuf_FileOptions *msg, upb_env *env, size_t *len);
@@ -447,7 +447,7 @@ void google_protobuf_FileOptions_set_uninterpreted_option(google_protobuf_FileOp
 
 
 /* google_protobuf_MessageOptions */
-extern const upb_msglayout_msginit_v1 google_protobuf_MessageOptions_msginit;
+extern const upb_msglayout google_protobuf_MessageOptions_msginit;
 google_protobuf_MessageOptions *google_protobuf_MessageOptions_new(upb_env *env);
 google_protobuf_MessageOptions *google_protobuf_MessageOptions_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_MessageOptions_serialize(google_protobuf_MessageOptions *msg, upb_env *env, size_t *len);
@@ -469,7 +469,7 @@ void google_protobuf_MessageOptions_set_uninterpreted_option(google_protobuf_Mes
 
 
 /* google_protobuf_FieldOptions */
-extern const upb_msglayout_msginit_v1 google_protobuf_FieldOptions_msginit;
+extern const upb_msglayout google_protobuf_FieldOptions_msginit;
 google_protobuf_FieldOptions *google_protobuf_FieldOptions_new(upb_env *env);
 google_protobuf_FieldOptions *google_protobuf_FieldOptions_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_FieldOptions_serialize(google_protobuf_FieldOptions *msg, upb_env *env, size_t *len);
@@ -495,7 +495,7 @@ void google_protobuf_FieldOptions_set_uninterpreted_option(google_protobuf_Field
 
 
 /* google_protobuf_OneofOptions */
-extern const upb_msglayout_msginit_v1 google_protobuf_OneofOptions_msginit;
+extern const upb_msglayout google_protobuf_OneofOptions_msginit;
 google_protobuf_OneofOptions *google_protobuf_OneofOptions_new(upb_env *env);
 google_protobuf_OneofOptions *google_protobuf_OneofOptions_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_OneofOptions_serialize(google_protobuf_OneofOptions *msg, upb_env *env, size_t *len);
@@ -509,7 +509,7 @@ void google_protobuf_OneofOptions_set_uninterpreted_option(google_protobuf_Oneof
 
 
 /* google_protobuf_EnumOptions */
-extern const upb_msglayout_msginit_v1 google_protobuf_EnumOptions_msginit;
+extern const upb_msglayout google_protobuf_EnumOptions_msginit;
 google_protobuf_EnumOptions *google_protobuf_EnumOptions_new(upb_env *env);
 google_protobuf_EnumOptions *google_protobuf_EnumOptions_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_EnumOptions_serialize(google_protobuf_EnumOptions *msg, upb_env *env, size_t *len);
@@ -527,7 +527,7 @@ void google_protobuf_EnumOptions_set_uninterpreted_option(google_protobuf_EnumOp
 
 
 /* google_protobuf_EnumValueOptions */
-extern const upb_msglayout_msginit_v1 google_protobuf_EnumValueOptions_msginit;
+extern const upb_msglayout google_protobuf_EnumValueOptions_msginit;
 google_protobuf_EnumValueOptions *google_protobuf_EnumValueOptions_new(upb_env *env);
 google_protobuf_EnumValueOptions *google_protobuf_EnumValueOptions_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_EnumValueOptions_serialize(google_protobuf_EnumValueOptions *msg, upb_env *env, size_t *len);
@@ -543,7 +543,7 @@ void google_protobuf_EnumValueOptions_set_uninterpreted_option(google_protobuf_E
 
 
 /* google_protobuf_ServiceOptions */
-extern const upb_msglayout_msginit_v1 google_protobuf_ServiceOptions_msginit;
+extern const upb_msglayout google_protobuf_ServiceOptions_msginit;
 google_protobuf_ServiceOptions *google_protobuf_ServiceOptions_new(upb_env *env);
 google_protobuf_ServiceOptions *google_protobuf_ServiceOptions_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_ServiceOptions_serialize(google_protobuf_ServiceOptions *msg, upb_env *env, size_t *len);
@@ -559,7 +559,7 @@ void google_protobuf_ServiceOptions_set_uninterpreted_option(google_protobuf_Ser
 
 
 /* google_protobuf_MethodOptions */
-extern const upb_msglayout_msginit_v1 google_protobuf_MethodOptions_msginit;
+extern const upb_msglayout google_protobuf_MethodOptions_msginit;
 google_protobuf_MethodOptions *google_protobuf_MethodOptions_new(upb_env *env);
 google_protobuf_MethodOptions *google_protobuf_MethodOptions_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_MethodOptions_serialize(google_protobuf_MethodOptions *msg, upb_env *env, size_t *len);
@@ -577,7 +577,7 @@ void google_protobuf_MethodOptions_set_uninterpreted_option(google_protobuf_Meth
 
 
 /* google_protobuf_UninterpretedOption */
-extern const upb_msglayout_msginit_v1 google_protobuf_UninterpretedOption_msginit;
+extern const upb_msglayout google_protobuf_UninterpretedOption_msginit;
 google_protobuf_UninterpretedOption *google_protobuf_UninterpretedOption_new(upb_env *env);
 google_protobuf_UninterpretedOption *google_protobuf_UninterpretedOption_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_UninterpretedOption_serialize(google_protobuf_UninterpretedOption *msg, upb_env *env, size_t *len);
@@ -603,7 +603,7 @@ void google_protobuf_UninterpretedOption_set_aggregate_value(google_protobuf_Uni
 
 
 /* google_protobuf_UninterpretedOption_NamePart */
-extern const upb_msglayout_msginit_v1 google_protobuf_UninterpretedOption_NamePart_msginit;
+extern const upb_msglayout google_protobuf_UninterpretedOption_NamePart_msginit;
 google_protobuf_UninterpretedOption_NamePart *google_protobuf_UninterpretedOption_NamePart_new(upb_env *env);
 google_protobuf_UninterpretedOption_NamePart *google_protobuf_UninterpretedOption_NamePart_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_UninterpretedOption_NamePart_serialize(google_protobuf_UninterpretedOption_NamePart *msg, upb_env *env, size_t *len);
@@ -619,7 +619,7 @@ void google_protobuf_UninterpretedOption_NamePart_set_is_extension(google_protob
 
 
 /* google_protobuf_SourceCodeInfo */
-extern const upb_msglayout_msginit_v1 google_protobuf_SourceCodeInfo_msginit;
+extern const upb_msglayout google_protobuf_SourceCodeInfo_msginit;
 google_protobuf_SourceCodeInfo *google_protobuf_SourceCodeInfo_new(upb_env *env);
 google_protobuf_SourceCodeInfo *google_protobuf_SourceCodeInfo_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_SourceCodeInfo_serialize(google_protobuf_SourceCodeInfo *msg, upb_env *env, size_t *len);
@@ -633,7 +633,7 @@ void google_protobuf_SourceCodeInfo_set_location(google_protobuf_SourceCodeInfo 
 
 
 /* google_protobuf_SourceCodeInfo_Location */
-extern const upb_msglayout_msginit_v1 google_protobuf_SourceCodeInfo_Location_msginit;
+extern const upb_msglayout google_protobuf_SourceCodeInfo_Location_msginit;
 google_protobuf_SourceCodeInfo_Location *google_protobuf_SourceCodeInfo_Location_new(upb_env *env);
 google_protobuf_SourceCodeInfo_Location *google_protobuf_SourceCodeInfo_Location_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_SourceCodeInfo_Location_serialize(google_protobuf_SourceCodeInfo_Location *msg, upb_env *env, size_t *len);
@@ -655,7 +655,7 @@ void google_protobuf_SourceCodeInfo_Location_set_leading_detached_comments(googl
 
 
 /* google_protobuf_GeneratedCodeInfo */
-extern const upb_msglayout_msginit_v1 google_protobuf_GeneratedCodeInfo_msginit;
+extern const upb_msglayout google_protobuf_GeneratedCodeInfo_msginit;
 google_protobuf_GeneratedCodeInfo *google_protobuf_GeneratedCodeInfo_new(upb_env *env);
 google_protobuf_GeneratedCodeInfo *google_protobuf_GeneratedCodeInfo_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_GeneratedCodeInfo_serialize(google_protobuf_GeneratedCodeInfo *msg, upb_env *env, size_t *len);
@@ -669,7 +669,7 @@ void google_protobuf_GeneratedCodeInfo_set_annotation(google_protobuf_GeneratedC
 
 
 /* google_protobuf_GeneratedCodeInfo_Annotation */
-extern const upb_msglayout_msginit_v1 google_protobuf_GeneratedCodeInfo_Annotation_msginit;
+extern const upb_msglayout google_protobuf_GeneratedCodeInfo_Annotation_msginit;
 google_protobuf_GeneratedCodeInfo_Annotation *google_protobuf_GeneratedCodeInfo_Annotation_new(upb_env *env);
 google_protobuf_GeneratedCodeInfo_Annotation *google_protobuf_GeneratedCodeInfo_Annotation_parsenew(upb_stringview buf, upb_env *env);
 char *google_protobuf_GeneratedCodeInfo_Annotation_serialize(google_protobuf_GeneratedCodeInfo_Annotation *msg, upb_env *env, size_t *len);

--- a/tools/make_c_api.lua
+++ b/tools/make_c_api.lua
@@ -223,7 +223,7 @@ local function write_h_file(filedef, append)
   for msg in filedef:defs(upb.DEF_MSG) do
     local msgname = to_cident(msg:full_name())
     append('/* %s */\n', msgname)
-    append('extern const upb_msglayout_msginit_v1 %s_msginit;\n', msgname)
+    append('extern const upb_msglayout %s_msginit;\n', msgname)
     append('%s *%s_new(upb_env *env);\n', msgname, msgname)
     append('%s *%s_parsenew(upb_stringview buf, upb_env *env);\n',
            msgname, msgname)
@@ -378,7 +378,7 @@ local function write_c_file(filedef, hfilename, append)
     if oneof_count > 0 then
       local oneofs_array_name = msgname .. "_oneofs"
       oneofs_array_ref = "&" .. oneofs_array_name .. "[0]"
-      append('static const upb_msglayout_oneofinit_v1 %s[%s] = {\n',
+      append('static const upb_msglayout_oneof %s[%s] = {\n',
              oneofs_array_name, oneof_count)
       for _, oneof in ipairs(oneofs_layout_order) do
         append('  {offsetof(%s, %s), offsetof(%s, %s_case)},\n',
@@ -392,7 +392,7 @@ local function write_c_file(filedef, hfilename, append)
       -- "submsgs" array for every strongly-connected component.
       local submsgs_array_name = msgname .. "_submsgs"
       submsgs_array_ref = "&" .. submsgs_array_name .. "[0]"
-      append('static const upb_msglayout_msginit_v1 *const %s[%s] = {\n',
+      append('static const upb_msglayout *const %s[%s] = {\n',
              submsgs_array_name, submsg_count)
 
       -- Create a deterministically-sorted array of submessage entries.
@@ -415,7 +415,7 @@ local function write_c_file(filedef, hfilename, append)
     if field_count > 0 then
       local fields_array_name = msgname .. "__fields"
       fields_array_ref = "&" .. fields_array_name .. "[0]"
-      append('static const upb_msglayout_fieldinit_v1 %s[%s] = {\n',
+      append('static const upb_msglayout_field %s[%s] = {\n',
              fields_array_name, field_count)
       for _, field in ipairs(fields_number_order) do
         local submsg_index = "UPB_NO_SUBMSG"
@@ -439,7 +439,7 @@ local function write_c_file(filedef, hfilename, append)
       append('};\n\n')
     end
 
-    append('const upb_msglayout_msginit_v1 %s_msginit = {\n', msgname)
+    append('const upb_msglayout %s_msginit = {\n', msgname)
     append('  %s,\n', submsgs_array_ref)
     append('  %s,\n', fields_array_ref)
     append('  %s,\n', oneofs_array_ref)

--- a/upb/bindings/lua/upb.h
+++ b/upb/bindings/lua/upb.h
@@ -9,6 +9,7 @@
 #include "upb/def.h"
 #include "upb/handlers.h"
 #include "upb/msg.h"
+#include "upb/msgfactory.h"
 
 /* Lua 5.1/5.2 compatibility code. */
 #if LUA_VERSION_NUM == 501

--- a/upb/decode.h
+++ b/upb/decode.h
@@ -9,8 +9,8 @@
 
 UPB_BEGIN_EXTERN_C
 
-bool upb_decode(upb_stringview buf, void *msg,
-                const upb_msglayout_msginit_v1 *l, upb_env *env);
+bool upb_decode(upb_stringview buf, void *msg, const upb_msglayout *l,
+                upb_env *env);
 
 UPB_END_EXTERN_C
 

--- a/upb/encode.h
+++ b/upb/encode.h
@@ -9,8 +9,8 @@
 
 UPB_BEGIN_EXTERN_C
 
-char *upb_encode(const void *msg, const upb_msglayout_msginit_v1 *l,
-                 upb_env *env, size_t *size);
+char *upb_encode(const void *msg, const upb_msglayout *l, upb_env *env,
+                 size_t *size);
 
 UPB_END_EXTERN_C
 

--- a/upb/msgfactory.c
+++ b/upb/msgfactory.c
@@ -1,0 +1,325 @@
+
+#include "upb/msgfactory.h"
+
+static bool is_power_of_two(size_t val) {
+  return (val & (val - 1)) == 0;
+}
+
+/* Align up to the given power of 2. */
+static size_t align_up(size_t val, size_t align) {
+  UPB_ASSERT(is_power_of_two(align));
+  return (val + align - 1) & ~(align - 1);
+}
+
+static size_t div_round_up(size_t n, size_t d) {
+  return (n + d - 1) / d;
+}
+
+static size_t upb_msgval_sizeof2(upb_fieldtype_t type) {
+  switch (type) {
+    case UPB_TYPE_DOUBLE:
+    case UPB_TYPE_INT64:
+    case UPB_TYPE_UINT64:
+      return 8;
+    case UPB_TYPE_ENUM:
+    case UPB_TYPE_INT32:
+    case UPB_TYPE_UINT32:
+    case UPB_TYPE_FLOAT:
+      return 4;
+    case UPB_TYPE_BOOL:
+      return 1;
+    case UPB_TYPE_MESSAGE:
+      return sizeof(void*);
+    case UPB_TYPE_BYTES:
+    case UPB_TYPE_STRING:
+      return sizeof(upb_stringview);
+  }
+  UPB_UNREACHABLE();
+}
+
+static uint8_t upb_msg_fielddefsize(const upb_fielddef *f) {
+  if (upb_fielddef_isseq(f)) {
+    return sizeof(void*);
+  } else {
+    return upb_msgval_sizeof2(upb_fielddef_type(f));
+  }
+}
+
+static upb_msgval upb_msgval_fromdefault(const upb_fielddef *f) {
+  switch (upb_fielddef_type(f)) {
+      case UPB_TYPE_FLOAT:
+        return upb_msgval_float(upb_fielddef_defaultfloat(f));
+      case UPB_TYPE_DOUBLE:
+        return upb_msgval_double(upb_fielddef_defaultdouble(f));
+      case UPB_TYPE_BOOL:
+        return upb_msgval_bool(upb_fielddef_defaultbool(f));
+      case UPB_TYPE_STRING:
+      case UPB_TYPE_BYTES: {
+        size_t len;
+        const char *ptr = upb_fielddef_defaultstr(f, &len);
+        return upb_msgval_makestr(ptr, len);
+      }
+      case UPB_TYPE_MESSAGE:
+        return upb_msgval_msg(NULL);
+      case UPB_TYPE_ENUM:
+      case UPB_TYPE_INT32:
+        return upb_msgval_int32(upb_fielddef_defaultint32(f));
+      case UPB_TYPE_UINT32:
+        return upb_msgval_uint32(upb_fielddef_defaultuint32(f));
+      case UPB_TYPE_INT64:
+        return upb_msgval_int64(upb_fielddef_defaultint64(f));
+      case UPB_TYPE_UINT64:
+        return upb_msgval_uint64(upb_fielddef_defaultuint64(f));
+      default:
+        UPB_ASSERT(false);
+        return upb_msgval_msg(NULL);
+  }
+}
+
+
+/** upb_msglayout *************************************************************/
+
+static void upb_msglayout_free(upb_msglayout *l) {
+  upb_gfree(l->default_msg);
+  upb_gfree(l);
+}
+
+static size_t upb_msglayout_place(upb_msglayout *l, size_t size) {
+  size_t ret;
+
+  l->size = align_up(l->size, size);
+  ret = l->size;
+  l->size += size;
+  return ret;
+}
+
+static bool upb_msglayout_initdefault(upb_msglayout *l, const upb_msgdef *m) {
+  upb_msg_field_iter it;
+
+  if (upb_msgdef_syntax(m) == UPB_SYNTAX_PROTO2 && l->size) {
+    /* Allocate default message and set default values in it. */
+    l->default_msg = upb_gmalloc(l->size);
+    if (!l->default_msg) {
+      return false;
+    }
+
+    memset(l->default_msg, 0, l->size);
+
+    for (upb_msg_field_begin(&it, m); !upb_msg_field_done(&it);
+         upb_msg_field_next(&it)) {
+      const upb_fielddef *f = upb_msg_iter_field(&it);
+
+      if (upb_fielddef_containingoneof(f)) {
+        continue;
+      }
+
+      /* TODO(haberman): handle strings. */
+      if (!upb_fielddef_isstring(f) && !upb_fielddef_issubmsg(f) &&
+          !upb_fielddef_isseq(f)) {
+        upb_msg_set(l->default_msg, upb_fielddef_index(f),
+                    upb_msgval_fromdefault(f), l);
+      }
+    }
+  }
+
+  return true;
+}
+
+static bool upb_msglayout_init(const upb_msgdef *m,
+                               upb_msglayout *l,
+                               upb_msgfactory *factory) {
+  upb_msg_field_iter it;
+  upb_msg_oneof_iter oit;
+  size_t hasbit;
+  size_t submsg_count = 0;
+  const upb_msglayout **submsgs;
+  upb_msglayout_field *fields;
+  upb_msglayout_oneof *oneofs;
+
+  for (upb_msg_field_begin(&it, m);
+       !upb_msg_field_done(&it);
+       upb_msg_field_next(&it)) {
+    const upb_fielddef* f = upb_msg_iter_field(&it);
+    if (upb_fielddef_issubmsg(f)) {
+      submsg_count++;
+    }
+  }
+
+  memset(l, 0, sizeof(*l));
+
+  fields = upb_gmalloc(upb_msgdef_numfields(m) * sizeof(*fields));
+  submsgs = upb_gmalloc(submsg_count * sizeof(*submsgs));
+  oneofs = upb_gmalloc(upb_msgdef_numoneofs(m) * sizeof(*oneofs));
+
+  if ((!fields && upb_msgdef_numfields(m)) ||
+      (!submsgs && submsg_count) ||
+      (!oneofs && upb_msgdef_numoneofs(m))) {
+    /* OOM. */
+    upb_gfree(fields);
+    upb_gfree(submsgs);
+    upb_gfree(oneofs);
+    return false;
+  }
+
+  l->field_count = upb_msgdef_numfields(m);
+  l->oneof_count = upb_msgdef_numoneofs(m);
+  l->fields = fields;
+  l->submsgs = submsgs;
+  l->oneofs = oneofs;
+  l->is_proto2 = (upb_msgdef_syntax(m) == UPB_SYNTAX_PROTO2);
+
+  /* Allocate data offsets in three stages:
+   *
+   * 1. hasbits.
+   * 2. regular fields.
+   * 3. oneof fields.
+   *
+   * OPT: There is a lot of room for optimization here to minimize the size.
+   */
+
+  /* Allocate hasbits and set basic field attributes. */
+  submsg_count = 0;
+  for (upb_msg_field_begin(&it, m), hasbit = 0;
+       !upb_msg_field_done(&it);
+       upb_msg_field_next(&it)) {
+    const upb_fielddef* f = upb_msg_iter_field(&it);
+    upb_msglayout_field *field = &fields[upb_fielddef_index(f)];
+
+    field->number = upb_fielddef_number(f);
+    field->descriptortype = upb_fielddef_descriptortype(f);
+    field->label = upb_fielddef_label(f);
+
+    if (upb_fielddef_containingoneof(f)) {
+      field->oneof_index = upb_oneofdef_index(upb_fielddef_containingoneof(f));
+    } else {
+      field->oneof_index = UPB_NOT_IN_ONEOF;
+    }
+
+    if (upb_fielddef_issubmsg(f)) {
+      const upb_msglayout *sub_layout =
+          upb_msgfactory_getlayout(factory, upb_fielddef_msgsubdef(f));
+      field->submsg_index = submsg_count++;
+      submsgs[field->submsg_index] = sub_layout;
+    } else {
+      field->submsg_index = UPB_NO_SUBMSG;
+    }
+
+    if (upb_fielddef_haspresence(f) && !upb_fielddef_containingoneof(f)) {
+      field->hasbit = hasbit++;
+    } else {
+      field->hasbit = UPB_NO_HASBIT;
+    }
+  }
+
+  /* Account for space used by hasbits. */
+  l->size = div_round_up(hasbit, 8);
+
+  /* Allocate non-oneof fields. */
+  for (upb_msg_field_begin(&it, m); !upb_msg_field_done(&it);
+       upb_msg_field_next(&it)) {
+    const upb_fielddef* f = upb_msg_iter_field(&it);
+    size_t field_size = upb_msg_fielddefsize(f);
+    size_t index = upb_fielddef_index(f);
+
+    if (upb_fielddef_containingoneof(f)) {
+      /* Oneofs are handled separately below. */
+      continue;
+    }
+
+    fields[index].offset = upb_msglayout_place(l, field_size);
+  }
+
+  /* Allocate oneof fields.  Each oneof field consists of a uint32 for the case
+   * and space for the actual data. */
+  for (upb_msg_oneof_begin(&oit, m); !upb_msg_oneof_done(&oit);
+       upb_msg_oneof_next(&oit)) {
+    const upb_oneofdef* o = upb_msg_iter_oneof(&oit);
+    upb_oneof_iter fit;
+
+    size_t case_size = sizeof(uint32_t);  /* Could potentially optimize this. */
+    upb_msglayout_oneof *oneof = &oneofs[upb_oneofdef_index(o)];
+    size_t field_size = 0;
+
+    /* Calculate field size: the max of all field sizes. */
+    for (upb_oneof_begin(&fit, o);
+         !upb_oneof_done(&fit);
+         upb_oneof_next(&fit)) {
+      const upb_fielddef* f = upb_oneof_iter_field(&fit);
+      field_size = UPB_MAX(field_size, upb_msg_fielddefsize(f));
+    }
+
+    /* Align and allocate case offset. */
+    oneof->case_offset = upb_msglayout_place(l, case_size);
+    oneof->data_offset = upb_msglayout_place(l, field_size);
+  }
+
+  /* Size of the entire structure should be a multiple of its greatest
+   * alignment.  TODO: track overall alignment for real? */
+  l->size = align_up(l->size, 8);
+
+  return upb_msglayout_initdefault(l, m);
+}
+
+
+/** upb_msgfactory ************************************************************/
+
+struct upb_msgfactory {
+  const upb_symtab *symtab;  /* We own a ref. */
+  upb_inttable layouts;
+  upb_inttable mergehandlers;
+};
+
+upb_msgfactory *upb_msgfactory_new(const upb_symtab *symtab) {
+  upb_msgfactory *ret = upb_gmalloc(sizeof(*ret));
+
+  ret->symtab = symtab;
+  upb_inttable_init(&ret->layouts, UPB_CTYPE_PTR);
+  upb_inttable_init(&ret->mergehandlers, UPB_CTYPE_CONSTPTR);
+
+  return ret;
+}
+
+void upb_msgfactory_free(upb_msgfactory *f) {
+  upb_inttable_iter i;
+  upb_inttable_begin(&i, &f->layouts);
+  for(; !upb_inttable_done(&i); upb_inttable_next(&i)) {
+    upb_msglayout *l = upb_value_getptr(upb_inttable_iter_value(&i));
+    upb_msglayout_free(l);
+  }
+
+  upb_inttable_begin(&i, &f->mergehandlers);
+  for(; !upb_inttable_done(&i); upb_inttable_next(&i)) {
+    const upb_handlers *h = upb_value_getconstptr(upb_inttable_iter_value(&i));
+    upb_handlers_unref(h, f);
+  }
+
+  upb_inttable_uninit(&f->layouts);
+  upb_inttable_uninit(&f->mergehandlers);
+  upb_gfree(f);
+}
+
+const upb_symtab *upb_msgfactory_symtab(const upb_msgfactory *f) {
+  return f->symtab;
+}
+
+const upb_msglayout *upb_msgfactory_getlayout(upb_msgfactory *f,
+                                              const upb_msgdef *m) {
+  upb_value v;
+  UPB_ASSERT(upb_symtab_lookupmsg(f->symtab, upb_msgdef_fullname(m)) == m);
+  UPB_ASSERT(!upb_msgdef_mapentry(m));
+
+  if (upb_inttable_lookupptr(&f->layouts, m, &v)) {
+    UPB_ASSERT(upb_value_getptr(v));
+    return upb_value_getptr(v);
+  } else {
+    /* In case of circular dependency, layout has to be inserted first. */
+    upb_msglayout *l = upb_gmalloc(sizeof(*l));
+    upb_msgfactory *mutable_f = (void*)f;
+    upb_inttable_insertptr(&mutable_f->layouts, m, upb_value_ptr(l));
+    UPB_ASSERT(l);
+    if (!upb_msglayout_init(m, l, f)) {
+      upb_msglayout_free(l);
+    }
+    return l;
+  }
+}

--- a/upb/msgfactory.h
+++ b/upb/msgfactory.h
@@ -1,0 +1,40 @@
+
+#include "upb/def.h"
+#include "upb/msg.h"
+
+#ifndef UPB_MSGFACTORY_H_
+#define UPB_MSGFACTORY_H_
+
+UPB_DECLARE_TYPE(upb::MessageFactory, upb_msgfactory)
+
+/** upb_msgfactory ************************************************************/
+
+/* A upb_msgfactory contains a cache of upb_msglayout, upb_handlers, and
+ * upb_visitorplan objects.  These are the objects necessary to represent,
+ * populate, and and visit upb_msg objects.
+ *
+ * These caches are all populated by upb_msgdef, and lazily created on demand.
+ */
+
+/* Creates and destroys a msgfactory, respectively.  The messages for this
+ * msgfactory must come from |symtab| (which should outlive the msgfactory). */
+upb_msgfactory *upb_msgfactory_new(const upb_symtab *symtab);
+void upb_msgfactory_free(upb_msgfactory *f);
+
+const upb_symtab *upb_msgfactory_symtab(const upb_msgfactory *f);
+
+/* The functions to get cached objects, lazily creating them on demand.  These
+ * all require:
+ *
+ * - m is in upb_msgfactory_symtab(f)
+ * - upb_msgdef_mapentry(m) == false (since map messages can't have layouts).
+ *
+ * The returned objects will live for as long as the msgfactory does.
+ *
+ * TODO(haberman): consider making this thread-safe and take a const
+ * upb_msgfactory. */
+const upb_msglayout *upb_msgfactory_getlayout(upb_msgfactory *f,
+                                              const upb_msgdef *m);
+
+
+#endif /* UPB_MSGFACTORY_H_ */


### PR DESCRIPTION
The goal of this is for the core not to depend on descriptors (defs).

Also got rid of the premature "v1" business that was attempting
to create a binary compatibility story.

Also added an in-progress CMakeLists.txt file.