### PR TITLE
Changed C API to only define structs, a table, and a few minimal inline function.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,9 @@ if(LUA_FOUND AND PROTOBUF_FOUND)
 
   add_custom_target(
     upbc ALL
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tools/upbc
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/tools/make_c_api.lua
+            ${CMAKE_CURRENT_SOURCE_DIR}/tools/upbc.lua
+            ${CMAKE_CURRENT_BINARY_DIR}/tools/upbc
             ${CMAKE_CURRENT_BINARY_DIR}/lua/upb.lua
             ${CMAKE_CURRENT_BINARY_DIR}/lua/upb/pb.lua
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,16 @@ endif()
 # Implement ASAN/UBSAN options
 if(UPB_ENABLE_ASAN)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
-  set(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fsanitize=address")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address")
 endif()
 
 if(UPB_ENABLE_UBSAN)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
-  set(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fsanitize=undefined")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address")
 endif()
 
 include_directories(.)
@@ -166,7 +170,8 @@ if(LUA_FOUND AND PROTOBUF_FOUND)
            ${CMAKE_CURRENT_BINARY_DIR}/google/protobuf/timestamp.upb.c
            ${CMAKE_CURRENT_BINARY_DIR}/google/protobuf/wrappers.upb.c
            ${CMAKE_CURRENT_BINARY_DIR}/conformance.upb.c
-    DEPENDS upbc ${CMAKE_CURRENT_SOURCE_DIR}/third_party/protobuf/conformance/conformance.proto
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tools/upbc
+            ${CMAKE_CURRENT_SOURCE_DIR}/third_party/protobuf/conformance/conformance.proto
     COMMAND protoc --include_imports
         ${CMAKE_CURRENT_SOURCE_DIR}/third_party/protobuf/conformance/conformance.proto
         ${CMAKE_CURRENT_SOURCE_DIR}/third_party/protobuf/src/google/protobuf/test_messages_proto3.proto
@@ -179,7 +184,8 @@ if(LUA_FOUND AND PROTOBUF_FOUND)
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/google/protobuf/descriptor.upb.h
            ${CMAKE_CURRENT_BINARY_DIR}/google/protobuf/descriptor.upb.c
-    DEPENDS upbc ${CMAKE_CURRENT_SOURCE_DIR}/google/protobuf/descriptor.proto
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tools/upbc
+            ${CMAKE_CURRENT_SOURCE_DIR}/google/protobuf/descriptor.proto
     COMMAND protoc
         ${CMAKE_CURRENT_SOURCE_DIR}/google/protobuf/descriptor.proto
         -I${CMAKE_CURRENT_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ endif()
 include_directories(.)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 set(CMAKE_CXX_FLAGS "-std=c++11 -W -Wall -Wno-sign-compare")
+set(CMAKE_C_FLAGS "-std=c89 -W -Wall -Wno-sign-compare")
 
 if(APPLE)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -undefined dynamic_lookup -flat_namespace")

--- a/google/protobuf/descriptor.upb.c
+++ b/google/protobuf/descriptor.upb.c
@@ -7,16 +7,9 @@
  * regenerated. */
 
 #include <stddef.h>
-#include "upb/decode.h"
-#include "upb/encode.h"
 #include "upb/msg.h"
-#include "upb/upb.h"
 #include "google/protobuf/descriptor.upb.h"
 
-
-struct google_protobuf_FileDescriptorSet {
-  upb_array* file;
-};
 
 static const upb_msglayout *const google_protobuf_FileDescriptorSet_submsgs[1] = {
   &google_protobuf_FileDescriptorProto_msginit,
@@ -32,43 +25,6 @@ const upb_msglayout google_protobuf_FileDescriptorSet_msginit = {
   NULL,
   NULL, /* TODO. default_msg */
   UPB_ALIGNED_SIZEOF(google_protobuf_FileDescriptorSet), 1, 0, false, true
-};
-
-google_protobuf_FileDescriptorSet *google_protobuf_FileDescriptorSet_new(upb_env *env) {
-  google_protobuf_FileDescriptorSet *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_FileDescriptorSet *google_protobuf_FileDescriptorSet_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_FileDescriptorSet *msg = google_protobuf_FileDescriptorSet_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_FileDescriptorSet_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_FileDescriptorSet_serialize(google_protobuf_FileDescriptorSet *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_FileDescriptorSet_msginit, env, size);
-}
-const upb_array* google_protobuf_FileDescriptorSet_file(const google_protobuf_FileDescriptorSet *msg) {
-  return msg->file;
-}
-void google_protobuf_FileDescriptorSet_set_file(google_protobuf_FileDescriptorSet *msg, upb_array* value) {
-  msg->file = value;
-}
-struct google_protobuf_FileDescriptorProto {
-  upb_stringview name;
-  upb_stringview package;
-  upb_stringview syntax;
-  google_protobuf_FileOptions* options;
-  google_protobuf_SourceCodeInfo* source_code_info;
-  upb_array* dependency;
-  upb_array* message_type;
-  upb_array* enum_type;
-  upb_array* service;
-  upb_array* extension;
-  upb_array* public_dependency;
-  upb_array* weak_dependency;
 };
 
 static const upb_msglayout *const google_protobuf_FileDescriptorProto_submsgs[6] = {
@@ -103,107 +59,6 @@ const upb_msglayout google_protobuf_FileDescriptorProto_msginit = {
   UPB_ALIGNED_SIZEOF(google_protobuf_FileDescriptorProto), 12, 0, false, true
 };
 
-google_protobuf_FileDescriptorProto *google_protobuf_FileDescriptorProto_new(upb_env *env) {
-  google_protobuf_FileDescriptorProto *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_FileDescriptorProto *google_protobuf_FileDescriptorProto_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_FileDescriptorProto *msg = google_protobuf_FileDescriptorProto_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_FileDescriptorProto_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_FileDescriptorProto_serialize(google_protobuf_FileDescriptorProto *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_FileDescriptorProto_msginit, env, size);
-}
-upb_stringview google_protobuf_FileDescriptorProto_name(const google_protobuf_FileDescriptorProto *msg) {
-  return msg->name;
-}
-void google_protobuf_FileDescriptorProto_set_name(google_protobuf_FileDescriptorProto *msg, upb_stringview value) {
-  msg->name = value;
-}
-upb_stringview google_protobuf_FileDescriptorProto_package(const google_protobuf_FileDescriptorProto *msg) {
-  return msg->package;
-}
-void google_protobuf_FileDescriptorProto_set_package(google_protobuf_FileDescriptorProto *msg, upb_stringview value) {
-  msg->package = value;
-}
-const upb_array* google_protobuf_FileDescriptorProto_dependency(const google_protobuf_FileDescriptorProto *msg) {
-  return msg->dependency;
-}
-void google_protobuf_FileDescriptorProto_set_dependency(google_protobuf_FileDescriptorProto *msg, upb_array* value) {
-  msg->dependency = value;
-}
-const upb_array* google_protobuf_FileDescriptorProto_message_type(const google_protobuf_FileDescriptorProto *msg) {
-  return msg->message_type;
-}
-void google_protobuf_FileDescriptorProto_set_message_type(google_protobuf_FileDescriptorProto *msg, upb_array* value) {
-  msg->message_type = value;
-}
-const upb_array* google_protobuf_FileDescriptorProto_enum_type(const google_protobuf_FileDescriptorProto *msg) {
-  return msg->enum_type;
-}
-void google_protobuf_FileDescriptorProto_set_enum_type(google_protobuf_FileDescriptorProto *msg, upb_array* value) {
-  msg->enum_type = value;
-}
-const upb_array* google_protobuf_FileDescriptorProto_service(const google_protobuf_FileDescriptorProto *msg) {
-  return msg->service;
-}
-void google_protobuf_FileDescriptorProto_set_service(google_protobuf_FileDescriptorProto *msg, upb_array* value) {
-  msg->service = value;
-}
-const upb_array* google_protobuf_FileDescriptorProto_extension(const google_protobuf_FileDescriptorProto *msg) {
-  return msg->extension;
-}
-void google_protobuf_FileDescriptorProto_set_extension(google_protobuf_FileDescriptorProto *msg, upb_array* value) {
-  msg->extension = value;
-}
-const google_protobuf_FileOptions* google_protobuf_FileDescriptorProto_options(const google_protobuf_FileDescriptorProto *msg) {
-  return msg->options;
-}
-void google_protobuf_FileDescriptorProto_set_options(google_protobuf_FileDescriptorProto *msg, google_protobuf_FileOptions* value) {
-  msg->options = value;
-}
-const google_protobuf_SourceCodeInfo* google_protobuf_FileDescriptorProto_source_code_info(const google_protobuf_FileDescriptorProto *msg) {
-  return msg->source_code_info;
-}
-void google_protobuf_FileDescriptorProto_set_source_code_info(google_protobuf_FileDescriptorProto *msg, google_protobuf_SourceCodeInfo* value) {
-  msg->source_code_info = value;
-}
-const upb_array* google_protobuf_FileDescriptorProto_public_dependency(const google_protobuf_FileDescriptorProto *msg) {
-  return msg->public_dependency;
-}
-void google_protobuf_FileDescriptorProto_set_public_dependency(google_protobuf_FileDescriptorProto *msg, upb_array* value) {
-  msg->public_dependency = value;
-}
-const upb_array* google_protobuf_FileDescriptorProto_weak_dependency(const google_protobuf_FileDescriptorProto *msg) {
-  return msg->weak_dependency;
-}
-void google_protobuf_FileDescriptorProto_set_weak_dependency(google_protobuf_FileDescriptorProto *msg, upb_array* value) {
-  msg->weak_dependency = value;
-}
-upb_stringview google_protobuf_FileDescriptorProto_syntax(const google_protobuf_FileDescriptorProto *msg) {
-  return msg->syntax;
-}
-void google_protobuf_FileDescriptorProto_set_syntax(google_protobuf_FileDescriptorProto *msg, upb_stringview value) {
-  msg->syntax = value;
-}
-struct google_protobuf_DescriptorProto {
-  upb_stringview name;
-  google_protobuf_MessageOptions* options;
-  upb_array* field;
-  upb_array* nested_type;
-  upb_array* enum_type;
-  upb_array* extension_range;
-  upb_array* extension;
-  upb_array* oneof_decl;
-  upb_array* reserved_range;
-  upb_array* reserved_name;
-};
-
 static const upb_msglayout *const google_protobuf_DescriptorProto_submsgs[8] = {
   &google_protobuf_DescriptorProto_msginit,
   &google_protobuf_DescriptorProto_ExtensionRange_msginit,
@@ -235,88 +90,6 @@ const upb_msglayout google_protobuf_DescriptorProto_msginit = {
   UPB_ALIGNED_SIZEOF(google_protobuf_DescriptorProto), 10, 0, false, true
 };
 
-google_protobuf_DescriptorProto *google_protobuf_DescriptorProto_new(upb_env *env) {
-  google_protobuf_DescriptorProto *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_DescriptorProto *google_protobuf_DescriptorProto_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_DescriptorProto *msg = google_protobuf_DescriptorProto_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_DescriptorProto_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_DescriptorProto_serialize(google_protobuf_DescriptorProto *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_DescriptorProto_msginit, env, size);
-}
-upb_stringview google_protobuf_DescriptorProto_name(const google_protobuf_DescriptorProto *msg) {
-  return msg->name;
-}
-void google_protobuf_DescriptorProto_set_name(google_protobuf_DescriptorProto *msg, upb_stringview value) {
-  msg->name = value;
-}
-const upb_array* google_protobuf_DescriptorProto_field(const google_protobuf_DescriptorProto *msg) {
-  return msg->field;
-}
-void google_protobuf_DescriptorProto_set_field(google_protobuf_DescriptorProto *msg, upb_array* value) {
-  msg->field = value;
-}
-const upb_array* google_protobuf_DescriptorProto_nested_type(const google_protobuf_DescriptorProto *msg) {
-  return msg->nested_type;
-}
-void google_protobuf_DescriptorProto_set_nested_type(google_protobuf_DescriptorProto *msg, upb_array* value) {
-  msg->nested_type = value;
-}
-const upb_array* google_protobuf_DescriptorProto_enum_type(const google_protobuf_DescriptorProto *msg) {
-  return msg->enum_type;
-}
-void google_protobuf_DescriptorProto_set_enum_type(google_protobuf_DescriptorProto *msg, upb_array* value) {
-  msg->enum_type = value;
-}
-const upb_array* google_protobuf_DescriptorProto_extension_range(const google_protobuf_DescriptorProto *msg) {
-  return msg->extension_range;
-}
-void google_protobuf_DescriptorProto_set_extension_range(google_protobuf_DescriptorProto *msg, upb_array* value) {
-  msg->extension_range = value;
-}
-const upb_array* google_protobuf_DescriptorProto_extension(const google_protobuf_DescriptorProto *msg) {
-  return msg->extension;
-}
-void google_protobuf_DescriptorProto_set_extension(google_protobuf_DescriptorProto *msg, upb_array* value) {
-  msg->extension = value;
-}
-const google_protobuf_MessageOptions* google_protobuf_DescriptorProto_options(const google_protobuf_DescriptorProto *msg) {
-  return msg->options;
-}
-void google_protobuf_DescriptorProto_set_options(google_protobuf_DescriptorProto *msg, google_protobuf_MessageOptions* value) {
-  msg->options = value;
-}
-const upb_array* google_protobuf_DescriptorProto_oneof_decl(const google_protobuf_DescriptorProto *msg) {
-  return msg->oneof_decl;
-}
-void google_protobuf_DescriptorProto_set_oneof_decl(google_protobuf_DescriptorProto *msg, upb_array* value) {
-  msg->oneof_decl = value;
-}
-const upb_array* google_protobuf_DescriptorProto_reserved_range(const google_protobuf_DescriptorProto *msg) {
-  return msg->reserved_range;
-}
-void google_protobuf_DescriptorProto_set_reserved_range(google_protobuf_DescriptorProto *msg, upb_array* value) {
-  msg->reserved_range = value;
-}
-const upb_array* google_protobuf_DescriptorProto_reserved_name(const google_protobuf_DescriptorProto *msg) {
-  return msg->reserved_name;
-}
-void google_protobuf_DescriptorProto_set_reserved_name(google_protobuf_DescriptorProto *msg, upb_array* value) {
-  msg->reserved_name = value;
-}
-struct google_protobuf_DescriptorProto_ExtensionRange {
-  int32_t start;
-  int32_t end;
-  google_protobuf_ExtensionRangeOptions* options;
-};
-
 static const upb_msglayout *const google_protobuf_DescriptorProto_ExtensionRange_submsgs[1] = {
   &google_protobuf_ExtensionRangeOptions_msginit,
 };
@@ -335,45 +108,6 @@ const upb_msglayout google_protobuf_DescriptorProto_ExtensionRange_msginit = {
   UPB_ALIGNED_SIZEOF(google_protobuf_DescriptorProto_ExtensionRange), 3, 0, false, true
 };
 
-google_protobuf_DescriptorProto_ExtensionRange *google_protobuf_DescriptorProto_ExtensionRange_new(upb_env *env) {
-  google_protobuf_DescriptorProto_ExtensionRange *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_DescriptorProto_ExtensionRange *google_protobuf_DescriptorProto_ExtensionRange_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_DescriptorProto_ExtensionRange *msg = google_protobuf_DescriptorProto_ExtensionRange_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_DescriptorProto_ExtensionRange_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_DescriptorProto_ExtensionRange_serialize(google_protobuf_DescriptorProto_ExtensionRange *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_DescriptorProto_ExtensionRange_msginit, env, size);
-}
-int32_t google_protobuf_DescriptorProto_ExtensionRange_start(const google_protobuf_DescriptorProto_ExtensionRange *msg) {
-  return msg->start;
-}
-void google_protobuf_DescriptorProto_ExtensionRange_set_start(google_protobuf_DescriptorProto_ExtensionRange *msg, int32_t value) {
-  msg->start = value;
-}
-int32_t google_protobuf_DescriptorProto_ExtensionRange_end(const google_protobuf_DescriptorProto_ExtensionRange *msg) {
-  return msg->end;
-}
-void google_protobuf_DescriptorProto_ExtensionRange_set_end(google_protobuf_DescriptorProto_ExtensionRange *msg, int32_t value) {
-  msg->end = value;
-}
-const google_protobuf_ExtensionRangeOptions* google_protobuf_DescriptorProto_ExtensionRange_options(const google_protobuf_DescriptorProto_ExtensionRange *msg) {
-  return msg->options;
-}
-void google_protobuf_DescriptorProto_ExtensionRange_set_options(google_protobuf_DescriptorProto_ExtensionRange *msg, google_protobuf_ExtensionRangeOptions* value) {
-  msg->options = value;
-}
-struct google_protobuf_DescriptorProto_ReservedRange {
-  int32_t start;
-  int32_t end;
-};
-
 static const upb_msglayout_field google_protobuf_DescriptorProto_ReservedRange__fields[2] = {
   {1, offsetof(google_protobuf_DescriptorProto_ReservedRange, start), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
   {2, offsetof(google_protobuf_DescriptorProto_ReservedRange, end), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
@@ -385,38 +119,6 @@ const upb_msglayout google_protobuf_DescriptorProto_ReservedRange_msginit = {
   NULL,
   NULL, /* TODO. default_msg */
   UPB_ALIGNED_SIZEOF(google_protobuf_DescriptorProto_ReservedRange), 2, 0, false, true
-};
-
-google_protobuf_DescriptorProto_ReservedRange *google_protobuf_DescriptorProto_ReservedRange_new(upb_env *env) {
-  google_protobuf_DescriptorProto_ReservedRange *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_DescriptorProto_ReservedRange *google_protobuf_DescriptorProto_ReservedRange_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_DescriptorProto_ReservedRange *msg = google_protobuf_DescriptorProto_ReservedRange_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_DescriptorProto_ReservedRange_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_DescriptorProto_ReservedRange_serialize(google_protobuf_DescriptorProto_ReservedRange *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_DescriptorProto_ReservedRange_msginit, env, size);
-}
-int32_t google_protobuf_DescriptorProto_ReservedRange_start(const google_protobuf_DescriptorProto_ReservedRange *msg) {
-  return msg->start;
-}
-void google_protobuf_DescriptorProto_ReservedRange_set_start(google_protobuf_DescriptorProto_ReservedRange *msg, int32_t value) {
-  msg->start = value;
-}
-int32_t google_protobuf_DescriptorProto_ReservedRange_end(const google_protobuf_DescriptorProto_ReservedRange *msg) {
-  return msg->end;
-}
-void google_protobuf_DescriptorProto_ReservedRange_set_end(google_protobuf_DescriptorProto_ReservedRange *msg, int32_t value) {
-  msg->end = value;
-}
-struct google_protobuf_ExtensionRangeOptions {
-  upb_array* uninterpreted_option;
 };
 
 static const upb_msglayout *const google_protobuf_ExtensionRangeOptions_submsgs[1] = {
@@ -433,41 +135,6 @@ const upb_msglayout google_protobuf_ExtensionRangeOptions_msginit = {
   NULL,
   NULL, /* TODO. default_msg */
   UPB_ALIGNED_SIZEOF(google_protobuf_ExtensionRangeOptions), 1, 0, false, true
-};
-
-google_protobuf_ExtensionRangeOptions *google_protobuf_ExtensionRangeOptions_new(upb_env *env) {
-  google_protobuf_ExtensionRangeOptions *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_ExtensionRangeOptions *google_protobuf_ExtensionRangeOptions_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_ExtensionRangeOptions *msg = google_protobuf_ExtensionRangeOptions_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_ExtensionRangeOptions_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_ExtensionRangeOptions_serialize(google_protobuf_ExtensionRangeOptions *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_ExtensionRangeOptions_msginit, env, size);
-}
-const upb_array* google_protobuf_ExtensionRangeOptions_uninterpreted_option(const google_protobuf_ExtensionRangeOptions *msg) {
-  return msg->uninterpreted_option;
-}
-void google_protobuf_ExtensionRangeOptions_set_uninterpreted_option(google_protobuf_ExtensionRangeOptions *msg, upb_array* value) {
-  msg->uninterpreted_option = value;
-}
-struct google_protobuf_FieldDescriptorProto {
-  google_protobuf_FieldDescriptorProto_Label label;
-  google_protobuf_FieldDescriptorProto_Type type;
-  int32_t number;
-  int32_t oneof_index;
-  upb_stringview name;
-  upb_stringview extendee;
-  upb_stringview type_name;
-  upb_stringview default_value;
-  upb_stringview json_name;
-  google_protobuf_FieldOptions* options;
 };
 
 static const upb_msglayout *const google_protobuf_FieldDescriptorProto_submsgs[1] = {
@@ -495,87 +162,6 @@ const upb_msglayout google_protobuf_FieldDescriptorProto_msginit = {
   UPB_ALIGNED_SIZEOF(google_protobuf_FieldDescriptorProto), 10, 0, false, true
 };
 
-google_protobuf_FieldDescriptorProto *google_protobuf_FieldDescriptorProto_new(upb_env *env) {
-  google_protobuf_FieldDescriptorProto *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_FieldDescriptorProto *google_protobuf_FieldDescriptorProto_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_FieldDescriptorProto *msg = google_protobuf_FieldDescriptorProto_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_FieldDescriptorProto_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_FieldDescriptorProto_serialize(google_protobuf_FieldDescriptorProto *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_FieldDescriptorProto_msginit, env, size);
-}
-upb_stringview google_protobuf_FieldDescriptorProto_name(const google_protobuf_FieldDescriptorProto *msg) {
-  return msg->name;
-}
-void google_protobuf_FieldDescriptorProto_set_name(google_protobuf_FieldDescriptorProto *msg, upb_stringview value) {
-  msg->name = value;
-}
-upb_stringview google_protobuf_FieldDescriptorProto_extendee(const google_protobuf_FieldDescriptorProto *msg) {
-  return msg->extendee;
-}
-void google_protobuf_FieldDescriptorProto_set_extendee(google_protobuf_FieldDescriptorProto *msg, upb_stringview value) {
-  msg->extendee = value;
-}
-int32_t google_protobuf_FieldDescriptorProto_number(const google_protobuf_FieldDescriptorProto *msg) {
-  return msg->number;
-}
-void google_protobuf_FieldDescriptorProto_set_number(google_protobuf_FieldDescriptorProto *msg, int32_t value) {
-  msg->number = value;
-}
-google_protobuf_FieldDescriptorProto_Label google_protobuf_FieldDescriptorProto_label(const google_protobuf_FieldDescriptorProto *msg) {
-  return msg->label;
-}
-void google_protobuf_FieldDescriptorProto_set_label(google_protobuf_FieldDescriptorProto *msg, google_protobuf_FieldDescriptorProto_Label value) {
-  msg->label = value;
-}
-google_protobuf_FieldDescriptorProto_Type google_protobuf_FieldDescriptorProto_type(const google_protobuf_FieldDescriptorProto *msg) {
-  return msg->type;
-}
-void google_protobuf_FieldDescriptorProto_set_type(google_protobuf_FieldDescriptorProto *msg, google_protobuf_FieldDescriptorProto_Type value) {
-  msg->type = value;
-}
-upb_stringview google_protobuf_FieldDescriptorProto_type_name(const google_protobuf_FieldDescriptorProto *msg) {
-  return msg->type_name;
-}
-void google_protobuf_FieldDescriptorProto_set_type_name(google_protobuf_FieldDescriptorProto *msg, upb_stringview value) {
-  msg->type_name = value;
-}
-upb_stringview google_protobuf_FieldDescriptorProto_default_value(const google_protobuf_FieldDescriptorProto *msg) {
-  return msg->default_value;
-}
-void google_protobuf_FieldDescriptorProto_set_default_value(google_protobuf_FieldDescriptorProto *msg, upb_stringview value) {
-  msg->default_value = value;
-}
-const google_protobuf_FieldOptions* google_protobuf_FieldDescriptorProto_options(const google_protobuf_FieldDescriptorProto *msg) {
-  return msg->options;
-}
-void google_protobuf_FieldDescriptorProto_set_options(google_protobuf_FieldDescriptorProto *msg, google_protobuf_FieldOptions* value) {
-  msg->options = value;
-}
-int32_t google_protobuf_FieldDescriptorProto_oneof_index(const google_protobuf_FieldDescriptorProto *msg) {
-  return msg->oneof_index;
-}
-void google_protobuf_FieldDescriptorProto_set_oneof_index(google_protobuf_FieldDescriptorProto *msg, int32_t value) {
-  msg->oneof_index = value;
-}
-upb_stringview google_protobuf_FieldDescriptorProto_json_name(const google_protobuf_FieldDescriptorProto *msg) {
-  return msg->json_name;
-}
-void google_protobuf_FieldDescriptorProto_set_json_name(google_protobuf_FieldDescriptorProto *msg, upb_stringview value) {
-  msg->json_name = value;
-}
-struct google_protobuf_OneofDescriptorProto {
-  upb_stringview name;
-  google_protobuf_OneofOptions* options;
-};
-
 static const upb_msglayout *const google_protobuf_OneofDescriptorProto_submsgs[1] = {
   &google_protobuf_OneofOptions_msginit,
 };
@@ -591,42 +177,6 @@ const upb_msglayout google_protobuf_OneofDescriptorProto_msginit = {
   NULL,
   NULL, /* TODO. default_msg */
   UPB_ALIGNED_SIZEOF(google_protobuf_OneofDescriptorProto), 2, 0, false, true
-};
-
-google_protobuf_OneofDescriptorProto *google_protobuf_OneofDescriptorProto_new(upb_env *env) {
-  google_protobuf_OneofDescriptorProto *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_OneofDescriptorProto *google_protobuf_OneofDescriptorProto_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_OneofDescriptorProto *msg = google_protobuf_OneofDescriptorProto_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_OneofDescriptorProto_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_OneofDescriptorProto_serialize(google_protobuf_OneofDescriptorProto *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_OneofDescriptorProto_msginit, env, size);
-}
-upb_stringview google_protobuf_OneofDescriptorProto_name(const google_protobuf_OneofDescriptorProto *msg) {
-  return msg->name;
-}
-void google_protobuf_OneofDescriptorProto_set_name(google_protobuf_OneofDescriptorProto *msg, upb_stringview value) {
-  msg->name = value;
-}
-const google_protobuf_OneofOptions* google_protobuf_OneofDescriptorProto_options(const google_protobuf_OneofDescriptorProto *msg) {
-  return msg->options;
-}
-void google_protobuf_OneofDescriptorProto_set_options(google_protobuf_OneofDescriptorProto *msg, google_protobuf_OneofOptions* value) {
-  msg->options = value;
-}
-struct google_protobuf_EnumDescriptorProto {
-  upb_stringview name;
-  google_protobuf_EnumOptions* options;
-  upb_array* value;
-  upb_array* reserved_range;
-  upb_array* reserved_name;
 };
 
 static const upb_msglayout *const google_protobuf_EnumDescriptorProto_submsgs[3] = {
@@ -651,57 +201,6 @@ const upb_msglayout google_protobuf_EnumDescriptorProto_msginit = {
   UPB_ALIGNED_SIZEOF(google_protobuf_EnumDescriptorProto), 5, 0, false, true
 };
 
-google_protobuf_EnumDescriptorProto *google_protobuf_EnumDescriptorProto_new(upb_env *env) {
-  google_protobuf_EnumDescriptorProto *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_EnumDescriptorProto *google_protobuf_EnumDescriptorProto_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_EnumDescriptorProto *msg = google_protobuf_EnumDescriptorProto_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_EnumDescriptorProto_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_EnumDescriptorProto_serialize(google_protobuf_EnumDescriptorProto *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_EnumDescriptorProto_msginit, env, size);
-}
-upb_stringview google_protobuf_EnumDescriptorProto_name(const google_protobuf_EnumDescriptorProto *msg) {
-  return msg->name;
-}
-void google_protobuf_EnumDescriptorProto_set_name(google_protobuf_EnumDescriptorProto *msg, upb_stringview value) {
-  msg->name = value;
-}
-const upb_array* google_protobuf_EnumDescriptorProto_value(const google_protobuf_EnumDescriptorProto *msg) {
-  return msg->value;
-}
-void google_protobuf_EnumDescriptorProto_set_value(google_protobuf_EnumDescriptorProto *msg, upb_array* value) {
-  msg->value = value;
-}
-const google_protobuf_EnumOptions* google_protobuf_EnumDescriptorProto_options(const google_protobuf_EnumDescriptorProto *msg) {
-  return msg->options;
-}
-void google_protobuf_EnumDescriptorProto_set_options(google_protobuf_EnumDescriptorProto *msg, google_protobuf_EnumOptions* value) {
-  msg->options = value;
-}
-const upb_array* google_protobuf_EnumDescriptorProto_reserved_range(const google_protobuf_EnumDescriptorProto *msg) {
-  return msg->reserved_range;
-}
-void google_protobuf_EnumDescriptorProto_set_reserved_range(google_protobuf_EnumDescriptorProto *msg, upb_array* value) {
-  msg->reserved_range = value;
-}
-const upb_array* google_protobuf_EnumDescriptorProto_reserved_name(const google_protobuf_EnumDescriptorProto *msg) {
-  return msg->reserved_name;
-}
-void google_protobuf_EnumDescriptorProto_set_reserved_name(google_protobuf_EnumDescriptorProto *msg, upb_array* value) {
-  msg->reserved_name = value;
-}
-struct google_protobuf_EnumDescriptorProto_EnumReservedRange {
-  int32_t start;
-  int32_t end;
-};
-
 static const upb_msglayout_field google_protobuf_EnumDescriptorProto_EnumReservedRange__fields[2] = {
   {1, offsetof(google_protobuf_EnumDescriptorProto_EnumReservedRange, start), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
   {2, offsetof(google_protobuf_EnumDescriptorProto_EnumReservedRange, end), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
@@ -713,40 +212,6 @@ const upb_msglayout google_protobuf_EnumDescriptorProto_EnumReservedRange_msgini
   NULL,
   NULL, /* TODO. default_msg */
   UPB_ALIGNED_SIZEOF(google_protobuf_EnumDescriptorProto_EnumReservedRange), 2, 0, false, true
-};
-
-google_protobuf_EnumDescriptorProto_EnumReservedRange *google_protobuf_EnumDescriptorProto_EnumReservedRange_new(upb_env *env) {
-  google_protobuf_EnumDescriptorProto_EnumReservedRange *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_EnumDescriptorProto_EnumReservedRange *google_protobuf_EnumDescriptorProto_EnumReservedRange_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_EnumDescriptorProto_EnumReservedRange *msg = google_protobuf_EnumDescriptorProto_EnumReservedRange_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_EnumDescriptorProto_EnumReservedRange_serialize(google_protobuf_EnumDescriptorProto_EnumReservedRange *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit, env, size);
-}
-int32_t google_protobuf_EnumDescriptorProto_EnumReservedRange_start(const google_protobuf_EnumDescriptorProto_EnumReservedRange *msg) {
-  return msg->start;
-}
-void google_protobuf_EnumDescriptorProto_EnumReservedRange_set_start(google_protobuf_EnumDescriptorProto_EnumReservedRange *msg, int32_t value) {
-  msg->start = value;
-}
-int32_t google_protobuf_EnumDescriptorProto_EnumReservedRange_end(const google_protobuf_EnumDescriptorProto_EnumReservedRange *msg) {
-  return msg->end;
-}
-void google_protobuf_EnumDescriptorProto_EnumReservedRange_set_end(google_protobuf_EnumDescriptorProto_EnumReservedRange *msg, int32_t value) {
-  msg->end = value;
-}
-struct google_protobuf_EnumValueDescriptorProto {
-  int32_t number;
-  upb_stringview name;
-  google_protobuf_EnumValueOptions* options;
 };
 
 static const upb_msglayout *const google_protobuf_EnumValueDescriptorProto_submsgs[1] = {
@@ -765,46 +230,6 @@ const upb_msglayout google_protobuf_EnumValueDescriptorProto_msginit = {
   NULL,
   NULL, /* TODO. default_msg */
   UPB_ALIGNED_SIZEOF(google_protobuf_EnumValueDescriptorProto), 3, 0, false, true
-};
-
-google_protobuf_EnumValueDescriptorProto *google_protobuf_EnumValueDescriptorProto_new(upb_env *env) {
-  google_protobuf_EnumValueDescriptorProto *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_EnumValueDescriptorProto *google_protobuf_EnumValueDescriptorProto_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_EnumValueDescriptorProto *msg = google_protobuf_EnumValueDescriptorProto_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_EnumValueDescriptorProto_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_EnumValueDescriptorProto_serialize(google_protobuf_EnumValueDescriptorProto *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_EnumValueDescriptorProto_msginit, env, size);
-}
-upb_stringview google_protobuf_EnumValueDescriptorProto_name(const google_protobuf_EnumValueDescriptorProto *msg) {
-  return msg->name;
-}
-void google_protobuf_EnumValueDescriptorProto_set_name(google_protobuf_EnumValueDescriptorProto *msg, upb_stringview value) {
-  msg->name = value;
-}
-int32_t google_protobuf_EnumValueDescriptorProto_number(const google_protobuf_EnumValueDescriptorProto *msg) {
-  return msg->number;
-}
-void google_protobuf_EnumValueDescriptorProto_set_number(google_protobuf_EnumValueDescriptorProto *msg, int32_t value) {
-  msg->number = value;
-}
-const google_protobuf_EnumValueOptions* google_protobuf_EnumValueDescriptorProto_options(const google_protobuf_EnumValueDescriptorProto *msg) {
-  return msg->options;
-}
-void google_protobuf_EnumValueDescriptorProto_set_options(google_protobuf_EnumValueDescriptorProto *msg, google_protobuf_EnumValueOptions* value) {
-  msg->options = value;
-}
-struct google_protobuf_ServiceDescriptorProto {
-  upb_stringview name;
-  google_protobuf_ServiceOptions* options;
-  upb_array* method;
 };
 
 static const upb_msglayout *const google_protobuf_ServiceDescriptorProto_submsgs[2] = {
@@ -826,49 +251,6 @@ const upb_msglayout google_protobuf_ServiceDescriptorProto_msginit = {
   UPB_ALIGNED_SIZEOF(google_protobuf_ServiceDescriptorProto), 3, 0, false, true
 };
 
-google_protobuf_ServiceDescriptorProto *google_protobuf_ServiceDescriptorProto_new(upb_env *env) {
-  google_protobuf_ServiceDescriptorProto *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_ServiceDescriptorProto *google_protobuf_ServiceDescriptorProto_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_ServiceDescriptorProto *msg = google_protobuf_ServiceDescriptorProto_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_ServiceDescriptorProto_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_ServiceDescriptorProto_serialize(google_protobuf_ServiceDescriptorProto *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_ServiceDescriptorProto_msginit, env, size);
-}
-upb_stringview google_protobuf_ServiceDescriptorProto_name(const google_protobuf_ServiceDescriptorProto *msg) {
-  return msg->name;
-}
-void google_protobuf_ServiceDescriptorProto_set_name(google_protobuf_ServiceDescriptorProto *msg, upb_stringview value) {
-  msg->name = value;
-}
-const upb_array* google_protobuf_ServiceDescriptorProto_method(const google_protobuf_ServiceDescriptorProto *msg) {
-  return msg->method;
-}
-void google_protobuf_ServiceDescriptorProto_set_method(google_protobuf_ServiceDescriptorProto *msg, upb_array* value) {
-  msg->method = value;
-}
-const google_protobuf_ServiceOptions* google_protobuf_ServiceDescriptorProto_options(const google_protobuf_ServiceDescriptorProto *msg) {
-  return msg->options;
-}
-void google_protobuf_ServiceDescriptorProto_set_options(google_protobuf_ServiceDescriptorProto *msg, google_protobuf_ServiceOptions* value) {
-  msg->options = value;
-}
-struct google_protobuf_MethodDescriptorProto {
-  bool client_streaming;
-  bool server_streaming;
-  upb_stringview name;
-  upb_stringview input_type;
-  upb_stringview output_type;
-  google_protobuf_MethodOptions* options;
-};
-
 static const upb_msglayout *const google_protobuf_MethodDescriptorProto_submsgs[1] = {
   &google_protobuf_MethodOptions_msginit,
 };
@@ -888,80 +270,6 @@ const upb_msglayout google_protobuf_MethodDescriptorProto_msginit = {
   NULL,
   NULL, /* TODO. default_msg */
   UPB_ALIGNED_SIZEOF(google_protobuf_MethodDescriptorProto), 6, 0, false, true
-};
-
-google_protobuf_MethodDescriptorProto *google_protobuf_MethodDescriptorProto_new(upb_env *env) {
-  google_protobuf_MethodDescriptorProto *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_MethodDescriptorProto *google_protobuf_MethodDescriptorProto_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_MethodDescriptorProto *msg = google_protobuf_MethodDescriptorProto_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_MethodDescriptorProto_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_MethodDescriptorProto_serialize(google_protobuf_MethodDescriptorProto *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_MethodDescriptorProto_msginit, env, size);
-}
-upb_stringview google_protobuf_MethodDescriptorProto_name(const google_protobuf_MethodDescriptorProto *msg) {
-  return msg->name;
-}
-void google_protobuf_MethodDescriptorProto_set_name(google_protobuf_MethodDescriptorProto *msg, upb_stringview value) {
-  msg->name = value;
-}
-upb_stringview google_protobuf_MethodDescriptorProto_input_type(const google_protobuf_MethodDescriptorProto *msg) {
-  return msg->input_type;
-}
-void google_protobuf_MethodDescriptorProto_set_input_type(google_protobuf_MethodDescriptorProto *msg, upb_stringview value) {
-  msg->input_type = value;
-}
-upb_stringview google_protobuf_MethodDescriptorProto_output_type(const google_protobuf_MethodDescriptorProto *msg) {
-  return msg->output_type;
-}
-void google_protobuf_MethodDescriptorProto_set_output_type(google_protobuf_MethodDescriptorProto *msg, upb_stringview value) {
-  msg->output_type = value;
-}
-const google_protobuf_MethodOptions* google_protobuf_MethodDescriptorProto_options(const google_protobuf_MethodDescriptorProto *msg) {
-  return msg->options;
-}
-void google_protobuf_MethodDescriptorProto_set_options(google_protobuf_MethodDescriptorProto *msg, google_protobuf_MethodOptions* value) {
-  msg->options = value;
-}
-bool google_protobuf_MethodDescriptorProto_client_streaming(const google_protobuf_MethodDescriptorProto *msg) {
-  return msg->client_streaming;
-}
-void google_protobuf_MethodDescriptorProto_set_client_streaming(google_protobuf_MethodDescriptorProto *msg, bool value) {
-  msg->client_streaming = value;
-}
-bool google_protobuf_MethodDescriptorProto_server_streaming(const google_protobuf_MethodDescriptorProto *msg) {
-  return msg->server_streaming;
-}
-void google_protobuf_MethodDescriptorProto_set_server_streaming(google_protobuf_MethodDescriptorProto *msg, bool value) {
-  msg->server_streaming = value;
-}
-struct google_protobuf_FileOptions {
-  google_protobuf_FileOptions_OptimizeMode optimize_for;
-  bool java_multiple_files;
-  bool cc_generic_services;
-  bool java_generic_services;
-  bool py_generic_services;
-  bool java_generate_equals_and_hash;
-  bool deprecated;
-  bool java_string_check_utf8;
-  bool cc_enable_arenas;
-  bool php_generic_services;
-  upb_stringview java_package;
-  upb_stringview java_outer_classname;
-  upb_stringview go_package;
-  upb_stringview objc_class_prefix;
-  upb_stringview csharp_namespace;
-  upb_stringview swift_prefix;
-  upb_stringview php_class_prefix;
-  upb_stringview php_namespace;
-  upb_array* uninterpreted_option;
 };
 
 static const upb_msglayout *const google_protobuf_FileOptions_submsgs[1] = {
@@ -998,144 +306,6 @@ const upb_msglayout google_protobuf_FileOptions_msginit = {
   UPB_ALIGNED_SIZEOF(google_protobuf_FileOptions), 19, 0, false, true
 };
 
-google_protobuf_FileOptions *google_protobuf_FileOptions_new(upb_env *env) {
-  google_protobuf_FileOptions *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_FileOptions *google_protobuf_FileOptions_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_FileOptions *msg = google_protobuf_FileOptions_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_FileOptions_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_FileOptions_serialize(google_protobuf_FileOptions *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_FileOptions_msginit, env, size);
-}
-upb_stringview google_protobuf_FileOptions_java_package(const google_protobuf_FileOptions *msg) {
-  return msg->java_package;
-}
-void google_protobuf_FileOptions_set_java_package(google_protobuf_FileOptions *msg, upb_stringview value) {
-  msg->java_package = value;
-}
-upb_stringview google_protobuf_FileOptions_java_outer_classname(const google_protobuf_FileOptions *msg) {
-  return msg->java_outer_classname;
-}
-void google_protobuf_FileOptions_set_java_outer_classname(google_protobuf_FileOptions *msg, upb_stringview value) {
-  msg->java_outer_classname = value;
-}
-google_protobuf_FileOptions_OptimizeMode google_protobuf_FileOptions_optimize_for(const google_protobuf_FileOptions *msg) {
-  return msg->optimize_for;
-}
-void google_protobuf_FileOptions_set_optimize_for(google_protobuf_FileOptions *msg, google_protobuf_FileOptions_OptimizeMode value) {
-  msg->optimize_for = value;
-}
-bool google_protobuf_FileOptions_java_multiple_files(const google_protobuf_FileOptions *msg) {
-  return msg->java_multiple_files;
-}
-void google_protobuf_FileOptions_set_java_multiple_files(google_protobuf_FileOptions *msg, bool value) {
-  msg->java_multiple_files = value;
-}
-upb_stringview google_protobuf_FileOptions_go_package(const google_protobuf_FileOptions *msg) {
-  return msg->go_package;
-}
-void google_protobuf_FileOptions_set_go_package(google_protobuf_FileOptions *msg, upb_stringview value) {
-  msg->go_package = value;
-}
-bool google_protobuf_FileOptions_cc_generic_services(const google_protobuf_FileOptions *msg) {
-  return msg->cc_generic_services;
-}
-void google_protobuf_FileOptions_set_cc_generic_services(google_protobuf_FileOptions *msg, bool value) {
-  msg->cc_generic_services = value;
-}
-bool google_protobuf_FileOptions_java_generic_services(const google_protobuf_FileOptions *msg) {
-  return msg->java_generic_services;
-}
-void google_protobuf_FileOptions_set_java_generic_services(google_protobuf_FileOptions *msg, bool value) {
-  msg->java_generic_services = value;
-}
-bool google_protobuf_FileOptions_py_generic_services(const google_protobuf_FileOptions *msg) {
-  return msg->py_generic_services;
-}
-void google_protobuf_FileOptions_set_py_generic_services(google_protobuf_FileOptions *msg, bool value) {
-  msg->py_generic_services = value;
-}
-bool google_protobuf_FileOptions_java_generate_equals_and_hash(const google_protobuf_FileOptions *msg) {
-  return msg->java_generate_equals_and_hash;
-}
-void google_protobuf_FileOptions_set_java_generate_equals_and_hash(google_protobuf_FileOptions *msg, bool value) {
-  msg->java_generate_equals_and_hash = value;
-}
-bool google_protobuf_FileOptions_deprecated(const google_protobuf_FileOptions *msg) {
-  return msg->deprecated;
-}
-void google_protobuf_FileOptions_set_deprecated(google_protobuf_FileOptions *msg, bool value) {
-  msg->deprecated = value;
-}
-bool google_protobuf_FileOptions_java_string_check_utf8(const google_protobuf_FileOptions *msg) {
-  return msg->java_string_check_utf8;
-}
-void google_protobuf_FileOptions_set_java_string_check_utf8(google_protobuf_FileOptions *msg, bool value) {
-  msg->java_string_check_utf8 = value;
-}
-bool google_protobuf_FileOptions_cc_enable_arenas(const google_protobuf_FileOptions *msg) {
-  return msg->cc_enable_arenas;
-}
-void google_protobuf_FileOptions_set_cc_enable_arenas(google_protobuf_FileOptions *msg, bool value) {
-  msg->cc_enable_arenas = value;
-}
-upb_stringview google_protobuf_FileOptions_objc_class_prefix(const google_protobuf_FileOptions *msg) {
-  return msg->objc_class_prefix;
-}
-void google_protobuf_FileOptions_set_objc_class_prefix(google_protobuf_FileOptions *msg, upb_stringview value) {
-  msg->objc_class_prefix = value;
-}
-upb_stringview google_protobuf_FileOptions_csharp_namespace(const google_protobuf_FileOptions *msg) {
-  return msg->csharp_namespace;
-}
-void google_protobuf_FileOptions_set_csharp_namespace(google_protobuf_FileOptions *msg, upb_stringview value) {
-  msg->csharp_namespace = value;
-}
-upb_stringview google_protobuf_FileOptions_swift_prefix(const google_protobuf_FileOptions *msg) {
-  return msg->swift_prefix;
-}
-void google_protobuf_FileOptions_set_swift_prefix(google_protobuf_FileOptions *msg, upb_stringview value) {
-  msg->swift_prefix = value;
-}
-upb_stringview google_protobuf_FileOptions_php_class_prefix(const google_protobuf_FileOptions *msg) {
-  return msg->php_class_prefix;
-}
-void google_protobuf_FileOptions_set_php_class_prefix(google_protobuf_FileOptions *msg, upb_stringview value) {
-  msg->php_class_prefix = value;
-}
-upb_stringview google_protobuf_FileOptions_php_namespace(const google_protobuf_FileOptions *msg) {
-  return msg->php_namespace;
-}
-void google_protobuf_FileOptions_set_php_namespace(google_protobuf_FileOptions *msg, upb_stringview value) {
-  msg->php_namespace = value;
-}
-bool google_protobuf_FileOptions_php_generic_services(const google_protobuf_FileOptions *msg) {
-  return msg->php_generic_services;
-}
-void google_protobuf_FileOptions_set_php_generic_services(google_protobuf_FileOptions *msg, bool value) {
-  msg->php_generic_services = value;
-}
-const upb_array* google_protobuf_FileOptions_uninterpreted_option(const google_protobuf_FileOptions *msg) {
-  return msg->uninterpreted_option;
-}
-void google_protobuf_FileOptions_set_uninterpreted_option(google_protobuf_FileOptions *msg, upb_array* value) {
-  msg->uninterpreted_option = value;
-}
-struct google_protobuf_MessageOptions {
-  bool message_set_wire_format;
-  bool no_standard_descriptor_accessor;
-  bool deprecated;
-  bool map_entry;
-  upb_array* uninterpreted_option;
-};
-
 static const upb_msglayout *const google_protobuf_MessageOptions_submsgs[1] = {
   &google_protobuf_UninterpretedOption_msginit,
 };
@@ -1154,62 +324,6 @@ const upb_msglayout google_protobuf_MessageOptions_msginit = {
   NULL,
   NULL, /* TODO. default_msg */
   UPB_ALIGNED_SIZEOF(google_protobuf_MessageOptions), 5, 0, false, true
-};
-
-google_protobuf_MessageOptions *google_protobuf_MessageOptions_new(upb_env *env) {
-  google_protobuf_MessageOptions *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_MessageOptions *google_protobuf_MessageOptions_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_MessageOptions *msg = google_protobuf_MessageOptions_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_MessageOptions_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_MessageOptions_serialize(google_protobuf_MessageOptions *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_MessageOptions_msginit, env, size);
-}
-bool google_protobuf_MessageOptions_message_set_wire_format(const google_protobuf_MessageOptions *msg) {
-  return msg->message_set_wire_format;
-}
-void google_protobuf_MessageOptions_set_message_set_wire_format(google_protobuf_MessageOptions *msg, bool value) {
-  msg->message_set_wire_format = value;
-}
-bool google_protobuf_MessageOptions_no_standard_descriptor_accessor(const google_protobuf_MessageOptions *msg) {
-  return msg->no_standard_descriptor_accessor;
-}
-void google_protobuf_MessageOptions_set_no_standard_descriptor_accessor(google_protobuf_MessageOptions *msg, bool value) {
-  msg->no_standard_descriptor_accessor = value;
-}
-bool google_protobuf_MessageOptions_deprecated(const google_protobuf_MessageOptions *msg) {
-  return msg->deprecated;
-}
-void google_protobuf_MessageOptions_set_deprecated(google_protobuf_MessageOptions *msg, bool value) {
-  msg->deprecated = value;
-}
-bool google_protobuf_MessageOptions_map_entry(const google_protobuf_MessageOptions *msg) {
-  return msg->map_entry;
-}
-void google_protobuf_MessageOptions_set_map_entry(google_protobuf_MessageOptions *msg, bool value) {
-  msg->map_entry = value;
-}
-const upb_array* google_protobuf_MessageOptions_uninterpreted_option(const google_protobuf_MessageOptions *msg) {
-  return msg->uninterpreted_option;
-}
-void google_protobuf_MessageOptions_set_uninterpreted_option(google_protobuf_MessageOptions *msg, upb_array* value) {
-  msg->uninterpreted_option = value;
-}
-struct google_protobuf_FieldOptions {
-  google_protobuf_FieldOptions_CType ctype;
-  google_protobuf_FieldOptions_JSType jstype;
-  bool packed;
-  bool deprecated;
-  bool lazy;
-  bool weak;
-  upb_array* uninterpreted_option;
 };
 
 static const upb_msglayout *const google_protobuf_FieldOptions_submsgs[1] = {
@@ -1234,68 +348,6 @@ const upb_msglayout google_protobuf_FieldOptions_msginit = {
   UPB_ALIGNED_SIZEOF(google_protobuf_FieldOptions), 7, 0, false, true
 };
 
-google_protobuf_FieldOptions *google_protobuf_FieldOptions_new(upb_env *env) {
-  google_protobuf_FieldOptions *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_FieldOptions *google_protobuf_FieldOptions_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_FieldOptions *msg = google_protobuf_FieldOptions_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_FieldOptions_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_FieldOptions_serialize(google_protobuf_FieldOptions *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_FieldOptions_msginit, env, size);
-}
-google_protobuf_FieldOptions_CType google_protobuf_FieldOptions_ctype(const google_protobuf_FieldOptions *msg) {
-  return msg->ctype;
-}
-void google_protobuf_FieldOptions_set_ctype(google_protobuf_FieldOptions *msg, google_protobuf_FieldOptions_CType value) {
-  msg->ctype = value;
-}
-bool google_protobuf_FieldOptions_packed(const google_protobuf_FieldOptions *msg) {
-  return msg->packed;
-}
-void google_protobuf_FieldOptions_set_packed(google_protobuf_FieldOptions *msg, bool value) {
-  msg->packed = value;
-}
-bool google_protobuf_FieldOptions_deprecated(const google_protobuf_FieldOptions *msg) {
-  return msg->deprecated;
-}
-void google_protobuf_FieldOptions_set_deprecated(google_protobuf_FieldOptions *msg, bool value) {
-  msg->deprecated = value;
-}
-bool google_protobuf_FieldOptions_lazy(const google_protobuf_FieldOptions *msg) {
-  return msg->lazy;
-}
-void google_protobuf_FieldOptions_set_lazy(google_protobuf_FieldOptions *msg, bool value) {
-  msg->lazy = value;
-}
-google_protobuf_FieldOptions_JSType google_protobuf_FieldOptions_jstype(const google_protobuf_FieldOptions *msg) {
-  return msg->jstype;
-}
-void google_protobuf_FieldOptions_set_jstype(google_protobuf_FieldOptions *msg, google_protobuf_FieldOptions_JSType value) {
-  msg->jstype = value;
-}
-bool google_protobuf_FieldOptions_weak(const google_protobuf_FieldOptions *msg) {
-  return msg->weak;
-}
-void google_protobuf_FieldOptions_set_weak(google_protobuf_FieldOptions *msg, bool value) {
-  msg->weak = value;
-}
-const upb_array* google_protobuf_FieldOptions_uninterpreted_option(const google_protobuf_FieldOptions *msg) {
-  return msg->uninterpreted_option;
-}
-void google_protobuf_FieldOptions_set_uninterpreted_option(google_protobuf_FieldOptions *msg, upb_array* value) {
-  msg->uninterpreted_option = value;
-}
-struct google_protobuf_OneofOptions {
-  upb_array* uninterpreted_option;
-};
-
 static const upb_msglayout *const google_protobuf_OneofOptions_submsgs[1] = {
   &google_protobuf_UninterpretedOption_msginit,
 };
@@ -1310,34 +362,6 @@ const upb_msglayout google_protobuf_OneofOptions_msginit = {
   NULL,
   NULL, /* TODO. default_msg */
   UPB_ALIGNED_SIZEOF(google_protobuf_OneofOptions), 1, 0, false, true
-};
-
-google_protobuf_OneofOptions *google_protobuf_OneofOptions_new(upb_env *env) {
-  google_protobuf_OneofOptions *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_OneofOptions *google_protobuf_OneofOptions_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_OneofOptions *msg = google_protobuf_OneofOptions_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_OneofOptions_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_OneofOptions_serialize(google_protobuf_OneofOptions *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_OneofOptions_msginit, env, size);
-}
-const upb_array* google_protobuf_OneofOptions_uninterpreted_option(const google_protobuf_OneofOptions *msg) {
-  return msg->uninterpreted_option;
-}
-void google_protobuf_OneofOptions_set_uninterpreted_option(google_protobuf_OneofOptions *msg, upb_array* value) {
-  msg->uninterpreted_option = value;
-}
-struct google_protobuf_EnumOptions {
-  bool allow_alias;
-  bool deprecated;
-  upb_array* uninterpreted_option;
 };
 
 static const upb_msglayout *const google_protobuf_EnumOptions_submsgs[1] = {
@@ -1358,45 +382,6 @@ const upb_msglayout google_protobuf_EnumOptions_msginit = {
   UPB_ALIGNED_SIZEOF(google_protobuf_EnumOptions), 3, 0, false, true
 };
 
-google_protobuf_EnumOptions *google_protobuf_EnumOptions_new(upb_env *env) {
-  google_protobuf_EnumOptions *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_EnumOptions *google_protobuf_EnumOptions_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_EnumOptions *msg = google_protobuf_EnumOptions_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_EnumOptions_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_EnumOptions_serialize(google_protobuf_EnumOptions *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_EnumOptions_msginit, env, size);
-}
-bool google_protobuf_EnumOptions_allow_alias(const google_protobuf_EnumOptions *msg) {
-  return msg->allow_alias;
-}
-void google_protobuf_EnumOptions_set_allow_alias(google_protobuf_EnumOptions *msg, bool value) {
-  msg->allow_alias = value;
-}
-bool google_protobuf_EnumOptions_deprecated(const google_protobuf_EnumOptions *msg) {
-  return msg->deprecated;
-}
-void google_protobuf_EnumOptions_set_deprecated(google_protobuf_EnumOptions *msg, bool value) {
-  msg->deprecated = value;
-}
-const upb_array* google_protobuf_EnumOptions_uninterpreted_option(const google_protobuf_EnumOptions *msg) {
-  return msg->uninterpreted_option;
-}
-void google_protobuf_EnumOptions_set_uninterpreted_option(google_protobuf_EnumOptions *msg, upb_array* value) {
-  msg->uninterpreted_option = value;
-}
-struct google_protobuf_EnumValueOptions {
-  bool deprecated;
-  upb_array* uninterpreted_option;
-};
-
 static const upb_msglayout *const google_protobuf_EnumValueOptions_submsgs[1] = {
   &google_protobuf_UninterpretedOption_msginit,
 };
@@ -1412,39 +397,6 @@ const upb_msglayout google_protobuf_EnumValueOptions_msginit = {
   NULL,
   NULL, /* TODO. default_msg */
   UPB_ALIGNED_SIZEOF(google_protobuf_EnumValueOptions), 2, 0, false, true
-};
-
-google_protobuf_EnumValueOptions *google_protobuf_EnumValueOptions_new(upb_env *env) {
-  google_protobuf_EnumValueOptions *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_EnumValueOptions *google_protobuf_EnumValueOptions_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_EnumValueOptions *msg = google_protobuf_EnumValueOptions_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_EnumValueOptions_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_EnumValueOptions_serialize(google_protobuf_EnumValueOptions *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_EnumValueOptions_msginit, env, size);
-}
-bool google_protobuf_EnumValueOptions_deprecated(const google_protobuf_EnumValueOptions *msg) {
-  return msg->deprecated;
-}
-void google_protobuf_EnumValueOptions_set_deprecated(google_protobuf_EnumValueOptions *msg, bool value) {
-  msg->deprecated = value;
-}
-const upb_array* google_protobuf_EnumValueOptions_uninterpreted_option(const google_protobuf_EnumValueOptions *msg) {
-  return msg->uninterpreted_option;
-}
-void google_protobuf_EnumValueOptions_set_uninterpreted_option(google_protobuf_EnumValueOptions *msg, upb_array* value) {
-  msg->uninterpreted_option = value;
-}
-struct google_protobuf_ServiceOptions {
-  bool deprecated;
-  upb_array* uninterpreted_option;
 };
 
 static const upb_msglayout *const google_protobuf_ServiceOptions_submsgs[1] = {
@@ -1464,40 +416,6 @@ const upb_msglayout google_protobuf_ServiceOptions_msginit = {
   UPB_ALIGNED_SIZEOF(google_protobuf_ServiceOptions), 2, 0, false, true
 };
 
-google_protobuf_ServiceOptions *google_protobuf_ServiceOptions_new(upb_env *env) {
-  google_protobuf_ServiceOptions *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_ServiceOptions *google_protobuf_ServiceOptions_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_ServiceOptions *msg = google_protobuf_ServiceOptions_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_ServiceOptions_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_ServiceOptions_serialize(google_protobuf_ServiceOptions *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_ServiceOptions_msginit, env, size);
-}
-bool google_protobuf_ServiceOptions_deprecated(const google_protobuf_ServiceOptions *msg) {
-  return msg->deprecated;
-}
-void google_protobuf_ServiceOptions_set_deprecated(google_protobuf_ServiceOptions *msg, bool value) {
-  msg->deprecated = value;
-}
-const upb_array* google_protobuf_ServiceOptions_uninterpreted_option(const google_protobuf_ServiceOptions *msg) {
-  return msg->uninterpreted_option;
-}
-void google_protobuf_ServiceOptions_set_uninterpreted_option(google_protobuf_ServiceOptions *msg, upb_array* value) {
-  msg->uninterpreted_option = value;
-}
-struct google_protobuf_MethodOptions {
-  google_protobuf_MethodOptions_IdempotencyLevel idempotency_level;
-  bool deprecated;
-  upb_array* uninterpreted_option;
-};
-
 static const upb_msglayout *const google_protobuf_MethodOptions_submsgs[1] = {
   &google_protobuf_UninterpretedOption_msginit,
 };
@@ -1514,50 +432,6 @@ const upb_msglayout google_protobuf_MethodOptions_msginit = {
   NULL,
   NULL, /* TODO. default_msg */
   UPB_ALIGNED_SIZEOF(google_protobuf_MethodOptions), 3, 0, false, true
-};
-
-google_protobuf_MethodOptions *google_protobuf_MethodOptions_new(upb_env *env) {
-  google_protobuf_MethodOptions *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_MethodOptions *google_protobuf_MethodOptions_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_MethodOptions *msg = google_protobuf_MethodOptions_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_MethodOptions_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_MethodOptions_serialize(google_protobuf_MethodOptions *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_MethodOptions_msginit, env, size);
-}
-bool google_protobuf_MethodOptions_deprecated(const google_protobuf_MethodOptions *msg) {
-  return msg->deprecated;
-}
-void google_protobuf_MethodOptions_set_deprecated(google_protobuf_MethodOptions *msg, bool value) {
-  msg->deprecated = value;
-}
-google_protobuf_MethodOptions_IdempotencyLevel google_protobuf_MethodOptions_idempotency_level(const google_protobuf_MethodOptions *msg) {
-  return msg->idempotency_level;
-}
-void google_protobuf_MethodOptions_set_idempotency_level(google_protobuf_MethodOptions *msg, google_protobuf_MethodOptions_IdempotencyLevel value) {
-  msg->idempotency_level = value;
-}
-const upb_array* google_protobuf_MethodOptions_uninterpreted_option(const google_protobuf_MethodOptions *msg) {
-  return msg->uninterpreted_option;
-}
-void google_protobuf_MethodOptions_set_uninterpreted_option(google_protobuf_MethodOptions *msg, upb_array* value) {
-  msg->uninterpreted_option = value;
-}
-struct google_protobuf_UninterpretedOption {
-  uint64_t positive_int_value;
-  int64_t negative_int_value;
-  double double_value;
-  upb_stringview identifier_value;
-  upb_stringview string_value;
-  upb_stringview aggregate_value;
-  upb_array* name;
 };
 
 static const upb_msglayout *const google_protobuf_UninterpretedOption_submsgs[1] = {
@@ -1582,69 +456,6 @@ const upb_msglayout google_protobuf_UninterpretedOption_msginit = {
   UPB_ALIGNED_SIZEOF(google_protobuf_UninterpretedOption), 7, 0, false, true
 };
 
-google_protobuf_UninterpretedOption *google_protobuf_UninterpretedOption_new(upb_env *env) {
-  google_protobuf_UninterpretedOption *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_UninterpretedOption *google_protobuf_UninterpretedOption_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_UninterpretedOption *msg = google_protobuf_UninterpretedOption_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_UninterpretedOption_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_UninterpretedOption_serialize(google_protobuf_UninterpretedOption *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_UninterpretedOption_msginit, env, size);
-}
-const upb_array* google_protobuf_UninterpretedOption_name(const google_protobuf_UninterpretedOption *msg) {
-  return msg->name;
-}
-void google_protobuf_UninterpretedOption_set_name(google_protobuf_UninterpretedOption *msg, upb_array* value) {
-  msg->name = value;
-}
-upb_stringview google_protobuf_UninterpretedOption_identifier_value(const google_protobuf_UninterpretedOption *msg) {
-  return msg->identifier_value;
-}
-void google_protobuf_UninterpretedOption_set_identifier_value(google_protobuf_UninterpretedOption *msg, upb_stringview value) {
-  msg->identifier_value = value;
-}
-uint64_t google_protobuf_UninterpretedOption_positive_int_value(const google_protobuf_UninterpretedOption *msg) {
-  return msg->positive_int_value;
-}
-void google_protobuf_UninterpretedOption_set_positive_int_value(google_protobuf_UninterpretedOption *msg, uint64_t value) {
-  msg->positive_int_value = value;
-}
-int64_t google_protobuf_UninterpretedOption_negative_int_value(const google_protobuf_UninterpretedOption *msg) {
-  return msg->negative_int_value;
-}
-void google_protobuf_UninterpretedOption_set_negative_int_value(google_protobuf_UninterpretedOption *msg, int64_t value) {
-  msg->negative_int_value = value;
-}
-double google_protobuf_UninterpretedOption_double_value(const google_protobuf_UninterpretedOption *msg) {
-  return msg->double_value;
-}
-void google_protobuf_UninterpretedOption_set_double_value(google_protobuf_UninterpretedOption *msg, double value) {
-  msg->double_value = value;
-}
-upb_stringview google_protobuf_UninterpretedOption_string_value(const google_protobuf_UninterpretedOption *msg) {
-  return msg->string_value;
-}
-void google_protobuf_UninterpretedOption_set_string_value(google_protobuf_UninterpretedOption *msg, upb_stringview value) {
-  msg->string_value = value;
-}
-upb_stringview google_protobuf_UninterpretedOption_aggregate_value(const google_protobuf_UninterpretedOption *msg) {
-  return msg->aggregate_value;
-}
-void google_protobuf_UninterpretedOption_set_aggregate_value(google_protobuf_UninterpretedOption *msg, upb_stringview value) {
-  msg->aggregate_value = value;
-}
-struct google_protobuf_UninterpretedOption_NamePart {
-  bool is_extension;
-  upb_stringview name_part;
-};
-
 static const upb_msglayout_field google_protobuf_UninterpretedOption_NamePart__fields[2] = {
   {1, offsetof(google_protobuf_UninterpretedOption_NamePart, name_part), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 2},
   {2, offsetof(google_protobuf_UninterpretedOption_NamePart, is_extension), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 2},
@@ -1656,38 +467,6 @@ const upb_msglayout google_protobuf_UninterpretedOption_NamePart_msginit = {
   NULL,
   NULL, /* TODO. default_msg */
   UPB_ALIGNED_SIZEOF(google_protobuf_UninterpretedOption_NamePart), 2, 0, false, true
-};
-
-google_protobuf_UninterpretedOption_NamePart *google_protobuf_UninterpretedOption_NamePart_new(upb_env *env) {
-  google_protobuf_UninterpretedOption_NamePart *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_UninterpretedOption_NamePart *google_protobuf_UninterpretedOption_NamePart_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_UninterpretedOption_NamePart *msg = google_protobuf_UninterpretedOption_NamePart_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_UninterpretedOption_NamePart_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_UninterpretedOption_NamePart_serialize(google_protobuf_UninterpretedOption_NamePart *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_UninterpretedOption_NamePart_msginit, env, size);
-}
-upb_stringview google_protobuf_UninterpretedOption_NamePart_name_part(const google_protobuf_UninterpretedOption_NamePart *msg) {
-  return msg->name_part;
-}
-void google_protobuf_UninterpretedOption_NamePart_set_name_part(google_protobuf_UninterpretedOption_NamePart *msg, upb_stringview value) {
-  msg->name_part = value;
-}
-bool google_protobuf_UninterpretedOption_NamePart_is_extension(const google_protobuf_UninterpretedOption_NamePart *msg) {
-  return msg->is_extension;
-}
-void google_protobuf_UninterpretedOption_NamePart_set_is_extension(google_protobuf_UninterpretedOption_NamePart *msg, bool value) {
-  msg->is_extension = value;
-}
-struct google_protobuf_SourceCodeInfo {
-  upb_array* location;
 };
 
 static const upb_msglayout *const google_protobuf_SourceCodeInfo_submsgs[1] = {
@@ -1706,36 +485,6 @@ const upb_msglayout google_protobuf_SourceCodeInfo_msginit = {
   UPB_ALIGNED_SIZEOF(google_protobuf_SourceCodeInfo), 1, 0, false, true
 };
 
-google_protobuf_SourceCodeInfo *google_protobuf_SourceCodeInfo_new(upb_env *env) {
-  google_protobuf_SourceCodeInfo *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_SourceCodeInfo *google_protobuf_SourceCodeInfo_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_SourceCodeInfo *msg = google_protobuf_SourceCodeInfo_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_SourceCodeInfo_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_SourceCodeInfo_serialize(google_protobuf_SourceCodeInfo *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_SourceCodeInfo_msginit, env, size);
-}
-const upb_array* google_protobuf_SourceCodeInfo_location(const google_protobuf_SourceCodeInfo *msg) {
-  return msg->location;
-}
-void google_protobuf_SourceCodeInfo_set_location(google_protobuf_SourceCodeInfo *msg, upb_array* value) {
-  msg->location = value;
-}
-struct google_protobuf_SourceCodeInfo_Location {
-  upb_stringview leading_comments;
-  upb_stringview trailing_comments;
-  upb_array* path;
-  upb_array* span;
-  upb_array* leading_detached_comments;
-};
-
 static const upb_msglayout_field google_protobuf_SourceCodeInfo_Location__fields[5] = {
   {1, offsetof(google_protobuf_SourceCodeInfo_Location, path), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 3},
   {2, offsetof(google_protobuf_SourceCodeInfo_Location, span), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 3},
@@ -1750,56 +499,6 @@ const upb_msglayout google_protobuf_SourceCodeInfo_Location_msginit = {
   NULL,
   NULL, /* TODO. default_msg */
   UPB_ALIGNED_SIZEOF(google_protobuf_SourceCodeInfo_Location), 5, 0, false, true
-};
-
-google_protobuf_SourceCodeInfo_Location *google_protobuf_SourceCodeInfo_Location_new(upb_env *env) {
-  google_protobuf_SourceCodeInfo_Location *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_SourceCodeInfo_Location *google_protobuf_SourceCodeInfo_Location_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_SourceCodeInfo_Location *msg = google_protobuf_SourceCodeInfo_Location_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_SourceCodeInfo_Location_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_SourceCodeInfo_Location_serialize(google_protobuf_SourceCodeInfo_Location *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_SourceCodeInfo_Location_msginit, env, size);
-}
-const upb_array* google_protobuf_SourceCodeInfo_Location_path(const google_protobuf_SourceCodeInfo_Location *msg) {
-  return msg->path;
-}
-void google_protobuf_SourceCodeInfo_Location_set_path(google_protobuf_SourceCodeInfo_Location *msg, upb_array* value) {
-  msg->path = value;
-}
-const upb_array* google_protobuf_SourceCodeInfo_Location_span(const google_protobuf_SourceCodeInfo_Location *msg) {
-  return msg->span;
-}
-void google_protobuf_SourceCodeInfo_Location_set_span(google_protobuf_SourceCodeInfo_Location *msg, upb_array* value) {
-  msg->span = value;
-}
-upb_stringview google_protobuf_SourceCodeInfo_Location_leading_comments(const google_protobuf_SourceCodeInfo_Location *msg) {
-  return msg->leading_comments;
-}
-void google_protobuf_SourceCodeInfo_Location_set_leading_comments(google_protobuf_SourceCodeInfo_Location *msg, upb_stringview value) {
-  msg->leading_comments = value;
-}
-upb_stringview google_protobuf_SourceCodeInfo_Location_trailing_comments(const google_protobuf_SourceCodeInfo_Location *msg) {
-  return msg->trailing_comments;
-}
-void google_protobuf_SourceCodeInfo_Location_set_trailing_comments(google_protobuf_SourceCodeInfo_Location *msg, upb_stringview value) {
-  msg->trailing_comments = value;
-}
-const upb_array* google_protobuf_SourceCodeInfo_Location_leading_detached_comments(const google_protobuf_SourceCodeInfo_Location *msg) {
-  return msg->leading_detached_comments;
-}
-void google_protobuf_SourceCodeInfo_Location_set_leading_detached_comments(google_protobuf_SourceCodeInfo_Location *msg, upb_array* value) {
-  msg->leading_detached_comments = value;
-}
-struct google_protobuf_GeneratedCodeInfo {
-  upb_array* annotation;
 };
 
 static const upb_msglayout *const google_protobuf_GeneratedCodeInfo_submsgs[1] = {
@@ -1818,35 +517,6 @@ const upb_msglayout google_protobuf_GeneratedCodeInfo_msginit = {
   UPB_ALIGNED_SIZEOF(google_protobuf_GeneratedCodeInfo), 1, 0, false, true
 };
 
-google_protobuf_GeneratedCodeInfo *google_protobuf_GeneratedCodeInfo_new(upb_env *env) {
-  google_protobuf_GeneratedCodeInfo *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_GeneratedCodeInfo *google_protobuf_GeneratedCodeInfo_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_GeneratedCodeInfo *msg = google_protobuf_GeneratedCodeInfo_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_GeneratedCodeInfo_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_GeneratedCodeInfo_serialize(google_protobuf_GeneratedCodeInfo *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_GeneratedCodeInfo_msginit, env, size);
-}
-const upb_array* google_protobuf_GeneratedCodeInfo_annotation(const google_protobuf_GeneratedCodeInfo *msg) {
-  return msg->annotation;
-}
-void google_protobuf_GeneratedCodeInfo_set_annotation(google_protobuf_GeneratedCodeInfo *msg, upb_array* value) {
-  msg->annotation = value;
-}
-struct google_protobuf_GeneratedCodeInfo_Annotation {
-  int32_t begin;
-  int32_t end;
-  upb_stringview source_file;
-  upb_array* path;
-};
-
 static const upb_msglayout_field google_protobuf_GeneratedCodeInfo_Annotation__fields[4] = {
   {1, offsetof(google_protobuf_GeneratedCodeInfo_Annotation, path), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 3},
   {2, offsetof(google_protobuf_GeneratedCodeInfo_Annotation, source_file), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
@@ -1862,43 +532,3 @@ const upb_msglayout google_protobuf_GeneratedCodeInfo_Annotation_msginit = {
   UPB_ALIGNED_SIZEOF(google_protobuf_GeneratedCodeInfo_Annotation), 4, 0, false, true
 };
 
-google_protobuf_GeneratedCodeInfo_Annotation *google_protobuf_GeneratedCodeInfo_Annotation_new(upb_env *env) {
-  google_protobuf_GeneratedCodeInfo_Annotation *msg = upb_env_malloc(env, sizeof(*msg));
-  memset(msg, 0, sizeof(*msg));  /* TODO: defaults */
-  return msg;
-}
-google_protobuf_GeneratedCodeInfo_Annotation *google_protobuf_GeneratedCodeInfo_Annotation_parsenew(upb_stringview buf, upb_env *env) {
-  google_protobuf_GeneratedCodeInfo_Annotation *msg = google_protobuf_GeneratedCodeInfo_Annotation_new(env);
-  if (upb_decode(buf, msg, &google_protobuf_GeneratedCodeInfo_Annotation_msginit, env)) {
-    return msg;
-  } else {
-    return NULL;
-  }
-}
-char *google_protobuf_GeneratedCodeInfo_Annotation_serialize(google_protobuf_GeneratedCodeInfo_Annotation *msg, upb_env *env, size_t *size) {
-  return upb_encode(msg, &google_protobuf_GeneratedCodeInfo_Annotation_msginit, env, size);
-}
-const upb_array* google_protobuf_GeneratedCodeInfo_Annotation_path(const google_protobuf_GeneratedCodeInfo_Annotation *msg) {
-  return msg->path;
-}
-void google_protobuf_GeneratedCodeInfo_Annotation_set_path(google_protobuf_GeneratedCodeInfo_Annotation *msg, upb_array* value) {
-  msg->path = value;
-}
-upb_stringview google_protobuf_GeneratedCodeInfo_Annotation_source_file(const google_protobuf_GeneratedCodeInfo_Annotation *msg) {
-  return msg->source_file;
-}
-void google_protobuf_GeneratedCodeInfo_Annotation_set_source_file(google_protobuf_GeneratedCodeInfo_Annotation *msg, upb_stringview value) {
-  msg->source_file = value;
-}
-int32_t google_protobuf_GeneratedCodeInfo_Annotation_begin(const google_protobuf_GeneratedCodeInfo_Annotation *msg) {
-  return msg->begin;
-}
-void google_protobuf_GeneratedCodeInfo_Annotation_set_begin(google_protobuf_GeneratedCodeInfo_Annotation *msg, int32_t value) {
-  msg->begin = value;
-}
-int32_t google_protobuf_GeneratedCodeInfo_Annotation_end(const google_protobuf_GeneratedCodeInfo_Annotation *msg) {
-  return msg->end;
-}
-void google_protobuf_GeneratedCodeInfo_Annotation_set_end(google_protobuf_GeneratedCodeInfo_Annotation *msg, int32_t value) {
-  msg->end = value;
-}

--- a/google/protobuf/descriptor.upb.c
+++ b/google/protobuf/descriptor.upb.c
@@ -16,7 +16,7 @@ static const upb_msglayout *const google_protobuf_FileDescriptorSet_submsgs[1] =
 };
 
 static const upb_msglayout_field google_protobuf_FileDescriptorSet__fields[1] = {
-  {1, offsetof(google_protobuf_FileDescriptorSet, file), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {1, UPB_SIZE(0, 0), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
 const upb_msglayout google_protobuf_FileDescriptorSet_msginit = {
@@ -24,7 +24,7 @@ const upb_msglayout google_protobuf_FileDescriptorSet_msginit = {
   &google_protobuf_FileDescriptorSet__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_FileDescriptorSet), 1, 0, false, true
+  UPB_SIZE(4, 8), 1, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_FileDescriptorProto_submsgs[6] = {
@@ -37,18 +37,18 @@ static const upb_msglayout *const google_protobuf_FileDescriptorProto_submsgs[6]
 };
 
 static const upb_msglayout_field google_protobuf_FileDescriptorProto__fields[12] = {
-  {1, offsetof(google_protobuf_FileDescriptorProto, name), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {2, offsetof(google_protobuf_FileDescriptorProto, package), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {3, offsetof(google_protobuf_FileDescriptorProto, dependency), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 3},
-  {4, offsetof(google_protobuf_FileDescriptorProto, message_type), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
-  {5, offsetof(google_protobuf_FileDescriptorProto, enum_type), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 1, 11, 3},
-  {6, offsetof(google_protobuf_FileDescriptorProto, service), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 4, 11, 3},
-  {7, offsetof(google_protobuf_FileDescriptorProto, extension), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 2, 11, 3},
-  {8, offsetof(google_protobuf_FileDescriptorProto, options), 3, UPB_NOT_IN_ONEOF, 3, 11, 1},
-  {9, offsetof(google_protobuf_FileDescriptorProto, source_code_info), 4, UPB_NOT_IN_ONEOF, 5, 11, 1},
-  {10, offsetof(google_protobuf_FileDescriptorProto, public_dependency), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 3},
-  {11, offsetof(google_protobuf_FileDescriptorProto, weak_dependency), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 3},
-  {12, offsetof(google_protobuf_FileDescriptorProto, syntax), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {1, UPB_SIZE(8, 16), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {2, UPB_SIZE(16, 32), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {3, UPB_SIZE(40, 80), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 3},
+  {4, UPB_SIZE(44, 88), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {5, UPB_SIZE(48, 96), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 1, 11, 3},
+  {6, UPB_SIZE(52, 104), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 4, 11, 3},
+  {7, UPB_SIZE(56, 112), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 2, 11, 3},
+  {8, UPB_SIZE(32, 64), 3, UPB_NOT_IN_ONEOF, 3, 11, 1},
+  {9, UPB_SIZE(36, 72), 4, UPB_NOT_IN_ONEOF, 5, 11, 1},
+  {10, UPB_SIZE(60, 120), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 3},
+  {11, UPB_SIZE(64, 128), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 3},
+  {12, UPB_SIZE(24, 48), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
 };
 
 const upb_msglayout google_protobuf_FileDescriptorProto_msginit = {
@@ -56,7 +56,7 @@ const upb_msglayout google_protobuf_FileDescriptorProto_msginit = {
   &google_protobuf_FileDescriptorProto__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_FileDescriptorProto), 12, 0, false, true
+  UPB_SIZE(72, 144), 12, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_DescriptorProto_submsgs[8] = {
@@ -70,16 +70,16 @@ static const upb_msglayout *const google_protobuf_DescriptorProto_submsgs[8] = {
 };
 
 static const upb_msglayout_field google_protobuf_DescriptorProto__fields[10] = {
-  {1, offsetof(google_protobuf_DescriptorProto, name), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {2, offsetof(google_protobuf_DescriptorProto, field), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 4, 11, 3},
-  {3, offsetof(google_protobuf_DescriptorProto, nested_type), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
-  {4, offsetof(google_protobuf_DescriptorProto, enum_type), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 3, 11, 3},
-  {5, offsetof(google_protobuf_DescriptorProto, extension_range), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 1, 11, 3},
-  {6, offsetof(google_protobuf_DescriptorProto, extension), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 4, 11, 3},
-  {7, offsetof(google_protobuf_DescriptorProto, options), 1, UPB_NOT_IN_ONEOF, 5, 11, 1},
-  {8, offsetof(google_protobuf_DescriptorProto, oneof_decl), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 6, 11, 3},
-  {9, offsetof(google_protobuf_DescriptorProto, reserved_range), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 2, 11, 3},
-  {10, offsetof(google_protobuf_DescriptorProto, reserved_name), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 3},
+  {1, UPB_SIZE(8, 16), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {2, UPB_SIZE(20, 40), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 4, 11, 3},
+  {3, UPB_SIZE(24, 48), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {4, UPB_SIZE(28, 56), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 3, 11, 3},
+  {5, UPB_SIZE(32, 64), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 1, 11, 3},
+  {6, UPB_SIZE(36, 72), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 4, 11, 3},
+  {7, UPB_SIZE(16, 32), 1, UPB_NOT_IN_ONEOF, 5, 11, 1},
+  {8, UPB_SIZE(40, 80), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 6, 11, 3},
+  {9, UPB_SIZE(44, 88), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 2, 11, 3},
+  {10, UPB_SIZE(48, 96), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 3},
 };
 
 const upb_msglayout google_protobuf_DescriptorProto_msginit = {
@@ -87,7 +87,7 @@ const upb_msglayout google_protobuf_DescriptorProto_msginit = {
   &google_protobuf_DescriptorProto__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_DescriptorProto), 10, 0, false, true
+  UPB_SIZE(56, 112), 10, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_DescriptorProto_ExtensionRange_submsgs[1] = {
@@ -95,9 +95,9 @@ static const upb_msglayout *const google_protobuf_DescriptorProto_ExtensionRange
 };
 
 static const upb_msglayout_field google_protobuf_DescriptorProto_ExtensionRange__fields[3] = {
-  {1, offsetof(google_protobuf_DescriptorProto_ExtensionRange, start), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
-  {2, offsetof(google_protobuf_DescriptorProto_ExtensionRange, end), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
-  {3, offsetof(google_protobuf_DescriptorProto_ExtensionRange, options), 2, UPB_NOT_IN_ONEOF, 0, 11, 1},
+  {1, UPB_SIZE(4, 4), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
+  {2, UPB_SIZE(8, 8), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
+  {3, UPB_SIZE(12, 16), 2, UPB_NOT_IN_ONEOF, 0, 11, 1},
 };
 
 const upb_msglayout google_protobuf_DescriptorProto_ExtensionRange_msginit = {
@@ -105,12 +105,12 @@ const upb_msglayout google_protobuf_DescriptorProto_ExtensionRange_msginit = {
   &google_protobuf_DescriptorProto_ExtensionRange__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_DescriptorProto_ExtensionRange), 3, 0, false, true
+  UPB_SIZE(16, 24), 3, 0, false, true
 };
 
 static const upb_msglayout_field google_protobuf_DescriptorProto_ReservedRange__fields[2] = {
-  {1, offsetof(google_protobuf_DescriptorProto_ReservedRange, start), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
-  {2, offsetof(google_protobuf_DescriptorProto_ReservedRange, end), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
+  {1, UPB_SIZE(4, 4), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
+  {2, UPB_SIZE(8, 8), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
 };
 
 const upb_msglayout google_protobuf_DescriptorProto_ReservedRange_msginit = {
@@ -118,7 +118,7 @@ const upb_msglayout google_protobuf_DescriptorProto_ReservedRange_msginit = {
   &google_protobuf_DescriptorProto_ReservedRange__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_DescriptorProto_ReservedRange), 2, 0, false, true
+  UPB_SIZE(12, 12), 2, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_ExtensionRangeOptions_submsgs[1] = {
@@ -126,7 +126,7 @@ static const upb_msglayout *const google_protobuf_ExtensionRangeOptions_submsgs[
 };
 
 static const upb_msglayout_field google_protobuf_ExtensionRangeOptions__fields[1] = {
-  {999, offsetof(google_protobuf_ExtensionRangeOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {999, UPB_SIZE(0, 0), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
 const upb_msglayout google_protobuf_ExtensionRangeOptions_msginit = {
@@ -134,7 +134,7 @@ const upb_msglayout google_protobuf_ExtensionRangeOptions_msginit = {
   &google_protobuf_ExtensionRangeOptions__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_ExtensionRangeOptions), 1, 0, false, true
+  UPB_SIZE(4, 8), 1, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_FieldDescriptorProto_submsgs[1] = {
@@ -142,16 +142,16 @@ static const upb_msglayout *const google_protobuf_FieldDescriptorProto_submsgs[1
 };
 
 static const upb_msglayout_field google_protobuf_FieldDescriptorProto__fields[10] = {
-  {1, offsetof(google_protobuf_FieldDescriptorProto, name), 4, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {2, offsetof(google_protobuf_FieldDescriptorProto, extendee), 5, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {3, offsetof(google_protobuf_FieldDescriptorProto, number), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
-  {4, offsetof(google_protobuf_FieldDescriptorProto, label), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 14, 1},
-  {5, offsetof(google_protobuf_FieldDescriptorProto, type), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 14, 1},
-  {6, offsetof(google_protobuf_FieldDescriptorProto, type_name), 6, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {7, offsetof(google_protobuf_FieldDescriptorProto, default_value), 7, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {8, offsetof(google_protobuf_FieldDescriptorProto, options), 9, UPB_NOT_IN_ONEOF, 0, 11, 1},
-  {9, offsetof(google_protobuf_FieldDescriptorProto, oneof_index), 3, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
-  {10, offsetof(google_protobuf_FieldDescriptorProto, json_name), 8, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {1, UPB_SIZE(32, 32), 4, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {2, UPB_SIZE(40, 48), 5, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {3, UPB_SIZE(24, 24), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
+  {4, UPB_SIZE(8, 8), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 14, 1},
+  {5, UPB_SIZE(16, 16), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 14, 1},
+  {6, UPB_SIZE(48, 64), 6, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {7, UPB_SIZE(56, 80), 7, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {8, UPB_SIZE(72, 112), 9, UPB_NOT_IN_ONEOF, 0, 11, 1},
+  {9, UPB_SIZE(28, 28), 3, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
+  {10, UPB_SIZE(64, 96), 8, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
 };
 
 const upb_msglayout google_protobuf_FieldDescriptorProto_msginit = {
@@ -159,7 +159,7 @@ const upb_msglayout google_protobuf_FieldDescriptorProto_msginit = {
   &google_protobuf_FieldDescriptorProto__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_FieldDescriptorProto), 10, 0, false, true
+  UPB_SIZE(80, 128), 10, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_OneofDescriptorProto_submsgs[1] = {
@@ -167,8 +167,8 @@ static const upb_msglayout *const google_protobuf_OneofDescriptorProto_submsgs[1
 };
 
 static const upb_msglayout_field google_protobuf_OneofDescriptorProto__fields[2] = {
-  {1, offsetof(google_protobuf_OneofDescriptorProto, name), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {2, offsetof(google_protobuf_OneofDescriptorProto, options), 1, UPB_NOT_IN_ONEOF, 0, 11, 1},
+  {1, UPB_SIZE(8, 16), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {2, UPB_SIZE(16, 32), 1, UPB_NOT_IN_ONEOF, 0, 11, 1},
 };
 
 const upb_msglayout google_protobuf_OneofDescriptorProto_msginit = {
@@ -176,7 +176,7 @@ const upb_msglayout google_protobuf_OneofDescriptorProto_msginit = {
   &google_protobuf_OneofDescriptorProto__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_OneofDescriptorProto), 2, 0, false, true
+  UPB_SIZE(24, 48), 2, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_EnumDescriptorProto_submsgs[3] = {
@@ -186,11 +186,11 @@ static const upb_msglayout *const google_protobuf_EnumDescriptorProto_submsgs[3]
 };
 
 static const upb_msglayout_field google_protobuf_EnumDescriptorProto__fields[5] = {
-  {1, offsetof(google_protobuf_EnumDescriptorProto, name), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {2, offsetof(google_protobuf_EnumDescriptorProto, value), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 2, 11, 3},
-  {3, offsetof(google_protobuf_EnumDescriptorProto, options), 1, UPB_NOT_IN_ONEOF, 1, 11, 1},
-  {4, offsetof(google_protobuf_EnumDescriptorProto, reserved_range), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
-  {5, offsetof(google_protobuf_EnumDescriptorProto, reserved_name), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 3},
+  {1, UPB_SIZE(8, 16), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {2, UPB_SIZE(20, 40), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 2, 11, 3},
+  {3, UPB_SIZE(16, 32), 1, UPB_NOT_IN_ONEOF, 1, 11, 1},
+  {4, UPB_SIZE(24, 48), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {5, UPB_SIZE(28, 56), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 3},
 };
 
 const upb_msglayout google_protobuf_EnumDescriptorProto_msginit = {
@@ -198,12 +198,12 @@ const upb_msglayout google_protobuf_EnumDescriptorProto_msginit = {
   &google_protobuf_EnumDescriptorProto__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_EnumDescriptorProto), 5, 0, false, true
+  UPB_SIZE(32, 64), 5, 0, false, true
 };
 
 static const upb_msglayout_field google_protobuf_EnumDescriptorProto_EnumReservedRange__fields[2] = {
-  {1, offsetof(google_protobuf_EnumDescriptorProto_EnumReservedRange, start), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
-  {2, offsetof(google_protobuf_EnumDescriptorProto_EnumReservedRange, end), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
+  {1, UPB_SIZE(4, 4), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
+  {2, UPB_SIZE(8, 8), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
 };
 
 const upb_msglayout google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit = {
@@ -211,7 +211,7 @@ const upb_msglayout google_protobuf_EnumDescriptorProto_EnumReservedRange_msgini
   &google_protobuf_EnumDescriptorProto_EnumReservedRange__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_EnumDescriptorProto_EnumReservedRange), 2, 0, false, true
+  UPB_SIZE(12, 12), 2, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_EnumValueDescriptorProto_submsgs[1] = {
@@ -219,9 +219,9 @@ static const upb_msglayout *const google_protobuf_EnumValueDescriptorProto_subms
 };
 
 static const upb_msglayout_field google_protobuf_EnumValueDescriptorProto__fields[3] = {
-  {1, offsetof(google_protobuf_EnumValueDescriptorProto, name), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {2, offsetof(google_protobuf_EnumValueDescriptorProto, number), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
-  {3, offsetof(google_protobuf_EnumValueDescriptorProto, options), 2, UPB_NOT_IN_ONEOF, 0, 11, 1},
+  {1, UPB_SIZE(8, 16), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {2, UPB_SIZE(4, 4), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
+  {3, UPB_SIZE(16, 32), 2, UPB_NOT_IN_ONEOF, 0, 11, 1},
 };
 
 const upb_msglayout google_protobuf_EnumValueDescriptorProto_msginit = {
@@ -229,7 +229,7 @@ const upb_msglayout google_protobuf_EnumValueDescriptorProto_msginit = {
   &google_protobuf_EnumValueDescriptorProto__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_EnumValueDescriptorProto), 3, 0, false, true
+  UPB_SIZE(24, 48), 3, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_ServiceDescriptorProto_submsgs[2] = {
@@ -238,9 +238,9 @@ static const upb_msglayout *const google_protobuf_ServiceDescriptorProto_submsgs
 };
 
 static const upb_msglayout_field google_protobuf_ServiceDescriptorProto__fields[3] = {
-  {1, offsetof(google_protobuf_ServiceDescriptorProto, name), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {2, offsetof(google_protobuf_ServiceDescriptorProto, method), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
-  {3, offsetof(google_protobuf_ServiceDescriptorProto, options), 1, UPB_NOT_IN_ONEOF, 1, 11, 1},
+  {1, UPB_SIZE(8, 16), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {2, UPB_SIZE(20, 40), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {3, UPB_SIZE(16, 32), 1, UPB_NOT_IN_ONEOF, 1, 11, 1},
 };
 
 const upb_msglayout google_protobuf_ServiceDescriptorProto_msginit = {
@@ -248,7 +248,7 @@ const upb_msglayout google_protobuf_ServiceDescriptorProto_msginit = {
   &google_protobuf_ServiceDescriptorProto__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_ServiceDescriptorProto), 3, 0, false, true
+  UPB_SIZE(24, 48), 3, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_MethodDescriptorProto_submsgs[1] = {
@@ -256,12 +256,12 @@ static const upb_msglayout *const google_protobuf_MethodDescriptorProto_submsgs[
 };
 
 static const upb_msglayout_field google_protobuf_MethodDescriptorProto__fields[6] = {
-  {1, offsetof(google_protobuf_MethodDescriptorProto, name), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {2, offsetof(google_protobuf_MethodDescriptorProto, input_type), 3, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {3, offsetof(google_protobuf_MethodDescriptorProto, output_type), 4, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {4, offsetof(google_protobuf_MethodDescriptorProto, options), 5, UPB_NOT_IN_ONEOF, 0, 11, 1},
-  {5, offsetof(google_protobuf_MethodDescriptorProto, client_streaming), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {6, offsetof(google_protobuf_MethodDescriptorProto, server_streaming), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {1, UPB_SIZE(8, 16), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {2, UPB_SIZE(16, 32), 3, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {3, UPB_SIZE(24, 48), 4, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {4, UPB_SIZE(32, 64), 5, UPB_NOT_IN_ONEOF, 0, 11, 1},
+  {5, UPB_SIZE(1, 1), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {6, UPB_SIZE(2, 2), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
 };
 
 const upb_msglayout google_protobuf_MethodDescriptorProto_msginit = {
@@ -269,7 +269,7 @@ const upb_msglayout google_protobuf_MethodDescriptorProto_msginit = {
   &google_protobuf_MethodDescriptorProto__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_MethodDescriptorProto), 6, 0, false, true
+  UPB_SIZE(40, 80), 6, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_FileOptions_submsgs[1] = {
@@ -277,25 +277,25 @@ static const upb_msglayout *const google_protobuf_FileOptions_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_FileOptions__fields[19] = {
-  {1, offsetof(google_protobuf_FileOptions, java_package), 10, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {8, offsetof(google_protobuf_FileOptions, java_outer_classname), 11, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {9, offsetof(google_protobuf_FileOptions, optimize_for), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 14, 1},
-  {10, offsetof(google_protobuf_FileOptions, java_multiple_files), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {11, offsetof(google_protobuf_FileOptions, go_package), 12, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {16, offsetof(google_protobuf_FileOptions, cc_generic_services), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {17, offsetof(google_protobuf_FileOptions, java_generic_services), 3, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {18, offsetof(google_protobuf_FileOptions, py_generic_services), 4, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {20, offsetof(google_protobuf_FileOptions, java_generate_equals_and_hash), 5, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {23, offsetof(google_protobuf_FileOptions, deprecated), 6, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {27, offsetof(google_protobuf_FileOptions, java_string_check_utf8), 7, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {31, offsetof(google_protobuf_FileOptions, cc_enable_arenas), 8, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {36, offsetof(google_protobuf_FileOptions, objc_class_prefix), 13, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {37, offsetof(google_protobuf_FileOptions, csharp_namespace), 14, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {39, offsetof(google_protobuf_FileOptions, swift_prefix), 15, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {40, offsetof(google_protobuf_FileOptions, php_class_prefix), 16, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {41, offsetof(google_protobuf_FileOptions, php_namespace), 17, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {42, offsetof(google_protobuf_FileOptions, php_generic_services), 9, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {999, offsetof(google_protobuf_FileOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {1, UPB_SIZE(32, 32), 10, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {8, UPB_SIZE(40, 48), 11, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {9, UPB_SIZE(8, 8), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 14, 1},
+  {10, UPB_SIZE(16, 16), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {11, UPB_SIZE(48, 64), 12, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {16, UPB_SIZE(17, 17), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {17, UPB_SIZE(18, 18), 3, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {18, UPB_SIZE(19, 19), 4, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {20, UPB_SIZE(20, 20), 5, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {23, UPB_SIZE(21, 21), 6, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {27, UPB_SIZE(22, 22), 7, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {31, UPB_SIZE(23, 23), 8, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {36, UPB_SIZE(56, 80), 13, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {37, UPB_SIZE(64, 96), 14, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {39, UPB_SIZE(72, 112), 15, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {40, UPB_SIZE(80, 128), 16, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {41, UPB_SIZE(88, 144), 17, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {42, UPB_SIZE(24, 24), 9, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {999, UPB_SIZE(96, 160), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
 const upb_msglayout google_protobuf_FileOptions_msginit = {
@@ -303,7 +303,7 @@ const upb_msglayout google_protobuf_FileOptions_msginit = {
   &google_protobuf_FileOptions__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_FileOptions), 19, 0, false, true
+  UPB_SIZE(104, 176), 19, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_MessageOptions_submsgs[1] = {
@@ -311,11 +311,11 @@ static const upb_msglayout *const google_protobuf_MessageOptions_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_MessageOptions__fields[5] = {
-  {1, offsetof(google_protobuf_MessageOptions, message_set_wire_format), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {2, offsetof(google_protobuf_MessageOptions, no_standard_descriptor_accessor), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {3, offsetof(google_protobuf_MessageOptions, deprecated), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {7, offsetof(google_protobuf_MessageOptions, map_entry), 3, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {999, offsetof(google_protobuf_MessageOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {1, UPB_SIZE(1, 1), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {2, UPB_SIZE(2, 2), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {3, UPB_SIZE(3, 3), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {7, UPB_SIZE(4, 4), 3, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {999, UPB_SIZE(8, 8), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
 const upb_msglayout google_protobuf_MessageOptions_msginit = {
@@ -323,7 +323,7 @@ const upb_msglayout google_protobuf_MessageOptions_msginit = {
   &google_protobuf_MessageOptions__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_MessageOptions), 5, 0, false, true
+  UPB_SIZE(12, 16), 5, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_FieldOptions_submsgs[1] = {
@@ -331,13 +331,13 @@ static const upb_msglayout *const google_protobuf_FieldOptions_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_FieldOptions__fields[7] = {
-  {1, offsetof(google_protobuf_FieldOptions, ctype), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 14, 1},
-  {2, offsetof(google_protobuf_FieldOptions, packed), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {3, offsetof(google_protobuf_FieldOptions, deprecated), 3, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {5, offsetof(google_protobuf_FieldOptions, lazy), 4, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {6, offsetof(google_protobuf_FieldOptions, jstype), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 14, 1},
-  {10, offsetof(google_protobuf_FieldOptions, weak), 5, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {999, offsetof(google_protobuf_FieldOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {1, UPB_SIZE(8, 8), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 14, 1},
+  {2, UPB_SIZE(24, 24), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {3, UPB_SIZE(25, 25), 3, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {5, UPB_SIZE(26, 26), 4, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {6, UPB_SIZE(16, 16), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 14, 1},
+  {10, UPB_SIZE(27, 27), 5, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {999, UPB_SIZE(28, 32), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
 const upb_msglayout google_protobuf_FieldOptions_msginit = {
@@ -345,7 +345,7 @@ const upb_msglayout google_protobuf_FieldOptions_msginit = {
   &google_protobuf_FieldOptions__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_FieldOptions), 7, 0, false, true
+  UPB_SIZE(32, 40), 7, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_OneofOptions_submsgs[1] = {
@@ -353,7 +353,7 @@ static const upb_msglayout *const google_protobuf_OneofOptions_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_OneofOptions__fields[1] = {
-  {999, offsetof(google_protobuf_OneofOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {999, UPB_SIZE(0, 0), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
 const upb_msglayout google_protobuf_OneofOptions_msginit = {
@@ -361,7 +361,7 @@ const upb_msglayout google_protobuf_OneofOptions_msginit = {
   &google_protobuf_OneofOptions__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_OneofOptions), 1, 0, false, true
+  UPB_SIZE(4, 8), 1, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_EnumOptions_submsgs[1] = {
@@ -369,9 +369,9 @@ static const upb_msglayout *const google_protobuf_EnumOptions_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_EnumOptions__fields[3] = {
-  {2, offsetof(google_protobuf_EnumOptions, allow_alias), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {3, offsetof(google_protobuf_EnumOptions, deprecated), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {999, offsetof(google_protobuf_EnumOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {2, UPB_SIZE(1, 1), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {3, UPB_SIZE(2, 2), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {999, UPB_SIZE(4, 8), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
 const upb_msglayout google_protobuf_EnumOptions_msginit = {
@@ -379,7 +379,7 @@ const upb_msglayout google_protobuf_EnumOptions_msginit = {
   &google_protobuf_EnumOptions__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_EnumOptions), 3, 0, false, true
+  UPB_SIZE(8, 16), 3, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_EnumValueOptions_submsgs[1] = {
@@ -387,8 +387,8 @@ static const upb_msglayout *const google_protobuf_EnumValueOptions_submsgs[1] = 
 };
 
 static const upb_msglayout_field google_protobuf_EnumValueOptions__fields[2] = {
-  {1, offsetof(google_protobuf_EnumValueOptions, deprecated), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {999, offsetof(google_protobuf_EnumValueOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {1, UPB_SIZE(1, 1), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {999, UPB_SIZE(4, 8), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
 const upb_msglayout google_protobuf_EnumValueOptions_msginit = {
@@ -396,7 +396,7 @@ const upb_msglayout google_protobuf_EnumValueOptions_msginit = {
   &google_protobuf_EnumValueOptions__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_EnumValueOptions), 2, 0, false, true
+  UPB_SIZE(8, 16), 2, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_ServiceOptions_submsgs[1] = {
@@ -404,8 +404,8 @@ static const upb_msglayout *const google_protobuf_ServiceOptions_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_ServiceOptions__fields[2] = {
-  {33, offsetof(google_protobuf_ServiceOptions, deprecated), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {999, offsetof(google_protobuf_ServiceOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {33, UPB_SIZE(1, 1), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {999, UPB_SIZE(4, 8), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
 const upb_msglayout google_protobuf_ServiceOptions_msginit = {
@@ -413,7 +413,7 @@ const upb_msglayout google_protobuf_ServiceOptions_msginit = {
   &google_protobuf_ServiceOptions__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_ServiceOptions), 2, 0, false, true
+  UPB_SIZE(8, 16), 2, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_MethodOptions_submsgs[1] = {
@@ -421,9 +421,9 @@ static const upb_msglayout *const google_protobuf_MethodOptions_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_MethodOptions__fields[3] = {
-  {33, offsetof(google_protobuf_MethodOptions, deprecated), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
-  {34, offsetof(google_protobuf_MethodOptions, idempotency_level), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 14, 1},
-  {999, offsetof(google_protobuf_MethodOptions, uninterpreted_option), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {33, UPB_SIZE(16, 16), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 1},
+  {34, UPB_SIZE(8, 8), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 14, 1},
+  {999, UPB_SIZE(20, 24), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
 const upb_msglayout google_protobuf_MethodOptions_msginit = {
@@ -431,7 +431,7 @@ const upb_msglayout google_protobuf_MethodOptions_msginit = {
   &google_protobuf_MethodOptions__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_MethodOptions), 3, 0, false, true
+  UPB_SIZE(24, 32), 3, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_UninterpretedOption_submsgs[1] = {
@@ -439,13 +439,13 @@ static const upb_msglayout *const google_protobuf_UninterpretedOption_submsgs[1]
 };
 
 static const upb_msglayout_field google_protobuf_UninterpretedOption__fields[7] = {
-  {2, offsetof(google_protobuf_UninterpretedOption, name), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
-  {3, offsetof(google_protobuf_UninterpretedOption, identifier_value), 3, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {4, offsetof(google_protobuf_UninterpretedOption, positive_int_value), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 4, 1},
-  {5, offsetof(google_protobuf_UninterpretedOption, negative_int_value), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 3, 1},
-  {6, offsetof(google_protobuf_UninterpretedOption, double_value), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 1, 1},
-  {7, offsetof(google_protobuf_UninterpretedOption, string_value), 4, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 12, 1},
-  {8, offsetof(google_protobuf_UninterpretedOption, aggregate_value), 5, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {2, UPB_SIZE(56, 80), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {3, UPB_SIZE(32, 32), 3, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {4, UPB_SIZE(8, 8), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 4, 1},
+  {5, UPB_SIZE(16, 16), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 3, 1},
+  {6, UPB_SIZE(24, 24), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 1, 1},
+  {7, UPB_SIZE(40, 48), 4, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 12, 1},
+  {8, UPB_SIZE(48, 64), 5, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
 };
 
 const upb_msglayout google_protobuf_UninterpretedOption_msginit = {
@@ -453,12 +453,12 @@ const upb_msglayout google_protobuf_UninterpretedOption_msginit = {
   &google_protobuf_UninterpretedOption__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_UninterpretedOption), 7, 0, false, true
+  UPB_SIZE(64, 96), 7, 0, false, true
 };
 
 static const upb_msglayout_field google_protobuf_UninterpretedOption_NamePart__fields[2] = {
-  {1, offsetof(google_protobuf_UninterpretedOption_NamePart, name_part), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 2},
-  {2, offsetof(google_protobuf_UninterpretedOption_NamePart, is_extension), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 2},
+  {1, UPB_SIZE(8, 16), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 2},
+  {2, UPB_SIZE(1, 1), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 8, 2},
 };
 
 const upb_msglayout google_protobuf_UninterpretedOption_NamePart_msginit = {
@@ -466,7 +466,7 @@ const upb_msglayout google_protobuf_UninterpretedOption_NamePart_msginit = {
   &google_protobuf_UninterpretedOption_NamePart__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_UninterpretedOption_NamePart), 2, 0, false, true
+  UPB_SIZE(16, 32), 2, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_SourceCodeInfo_submsgs[1] = {
@@ -474,7 +474,7 @@ static const upb_msglayout *const google_protobuf_SourceCodeInfo_submsgs[1] = {
 };
 
 static const upb_msglayout_field google_protobuf_SourceCodeInfo__fields[1] = {
-  {1, offsetof(google_protobuf_SourceCodeInfo, location), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {1, UPB_SIZE(0, 0), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
 const upb_msglayout google_protobuf_SourceCodeInfo_msginit = {
@@ -482,15 +482,15 @@ const upb_msglayout google_protobuf_SourceCodeInfo_msginit = {
   &google_protobuf_SourceCodeInfo__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_SourceCodeInfo), 1, 0, false, true
+  UPB_SIZE(4, 8), 1, 0, false, true
 };
 
 static const upb_msglayout_field google_protobuf_SourceCodeInfo_Location__fields[5] = {
-  {1, offsetof(google_protobuf_SourceCodeInfo_Location, path), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 3},
-  {2, offsetof(google_protobuf_SourceCodeInfo_Location, span), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 3},
-  {3, offsetof(google_protobuf_SourceCodeInfo_Location, leading_comments), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {4, offsetof(google_protobuf_SourceCodeInfo_Location, trailing_comments), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {6, offsetof(google_protobuf_SourceCodeInfo_Location, leading_detached_comments), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 3},
+  {1, UPB_SIZE(24, 48), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 3},
+  {2, UPB_SIZE(28, 56), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 3},
+  {3, UPB_SIZE(8, 16), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {4, UPB_SIZE(16, 32), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {6, UPB_SIZE(32, 64), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 3},
 };
 
 const upb_msglayout google_protobuf_SourceCodeInfo_Location_msginit = {
@@ -498,7 +498,7 @@ const upb_msglayout google_protobuf_SourceCodeInfo_Location_msginit = {
   &google_protobuf_SourceCodeInfo_Location__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_SourceCodeInfo_Location), 5, 0, false, true
+  UPB_SIZE(40, 80), 5, 0, false, true
 };
 
 static const upb_msglayout *const google_protobuf_GeneratedCodeInfo_submsgs[1] = {
@@ -506,7 +506,7 @@ static const upb_msglayout *const google_protobuf_GeneratedCodeInfo_submsgs[1] =
 };
 
 static const upb_msglayout_field google_protobuf_GeneratedCodeInfo__fields[1] = {
-  {1, offsetof(google_protobuf_GeneratedCodeInfo, annotation), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
+  {1, UPB_SIZE(0, 0), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, 0, 11, 3},
 };
 
 const upb_msglayout google_protobuf_GeneratedCodeInfo_msginit = {
@@ -514,14 +514,14 @@ const upb_msglayout google_protobuf_GeneratedCodeInfo_msginit = {
   &google_protobuf_GeneratedCodeInfo__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_GeneratedCodeInfo), 1, 0, false, true
+  UPB_SIZE(4, 8), 1, 0, false, true
 };
 
 static const upb_msglayout_field google_protobuf_GeneratedCodeInfo_Annotation__fields[4] = {
-  {1, offsetof(google_protobuf_GeneratedCodeInfo_Annotation, path), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 3},
-  {2, offsetof(google_protobuf_GeneratedCodeInfo_Annotation, source_file), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
-  {3, offsetof(google_protobuf_GeneratedCodeInfo_Annotation, begin), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
-  {4, offsetof(google_protobuf_GeneratedCodeInfo_Annotation, end), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
+  {1, UPB_SIZE(24, 32), UPB_NO_HASBIT, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 3},
+  {2, UPB_SIZE(16, 16), 2, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 9, 1},
+  {3, UPB_SIZE(4, 4), 0, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
+  {4, UPB_SIZE(8, 8), 1, UPB_NOT_IN_ONEOF, UPB_NO_SUBMSG, 5, 1},
 };
 
 const upb_msglayout google_protobuf_GeneratedCodeInfo_Annotation_msginit = {
@@ -529,6 +529,6 @@ const upb_msglayout google_protobuf_GeneratedCodeInfo_Annotation_msginit = {
   &google_protobuf_GeneratedCodeInfo_Annotation__fields[0],
   NULL,
   NULL, /* TODO. default_msg */
-  UPB_ALIGNED_SIZEOF(google_protobuf_GeneratedCodeInfo_Annotation), 4, 0, false, true
+  UPB_SIZE(32, 48), 4, 0, false, true
 };
 

--- a/google/protobuf/descriptor.upb.c
+++ b/google/protobuf/descriptor.upb.c
@@ -10,6 +10,7 @@
 #include "upb/msg.h"
 #include "google/protobuf/descriptor.upb.h"
 
+#include "upb/port_def.inc"
 
 static const upb_msglayout *const google_protobuf_FileDescriptorSet_submsgs[1] = {
   &google_protobuf_FileDescriptorProto_msginit,
@@ -531,4 +532,6 @@ const upb_msglayout google_protobuf_GeneratedCodeInfo_Annotation_msginit = {
   NULL, /* TODO. default_msg */
   UPB_SIZE(32, 48), 4, 0, false, true
 };
+
+#include "upb/port_undef.inc"
 

--- a/google/protobuf/descriptor.upb.h
+++ b/google/protobuf/descriptor.upb.h
@@ -13,62 +13,36 @@
 
 #include "upb/decode.h"
 #include "upb/encode.h"
+#include "upb/port_def.inc"
 UPB_BEGIN_EXTERN_C
 
-struct google_protobuf_FileDescriptorSet;
-typedef struct google_protobuf_FileDescriptorSet google_protobuf_FileDescriptorSet;
-struct google_protobuf_FileDescriptorProto;
-typedef struct google_protobuf_FileDescriptorProto google_protobuf_FileDescriptorProto;
-struct google_protobuf_DescriptorProto;
-typedef struct google_protobuf_DescriptorProto google_protobuf_DescriptorProto;
-struct google_protobuf_DescriptorProto_ExtensionRange;
-typedef struct google_protobuf_DescriptorProto_ExtensionRange google_protobuf_DescriptorProto_ExtensionRange;
-struct google_protobuf_DescriptorProto_ReservedRange;
-typedef struct google_protobuf_DescriptorProto_ReservedRange google_protobuf_DescriptorProto_ReservedRange;
-struct google_protobuf_ExtensionRangeOptions;
-typedef struct google_protobuf_ExtensionRangeOptions google_protobuf_ExtensionRangeOptions;
-struct google_protobuf_FieldDescriptorProto;
-typedef struct google_protobuf_FieldDescriptorProto google_protobuf_FieldDescriptorProto;
-struct google_protobuf_OneofDescriptorProto;
-typedef struct google_protobuf_OneofDescriptorProto google_protobuf_OneofDescriptorProto;
-struct google_protobuf_EnumDescriptorProto;
-typedef struct google_protobuf_EnumDescriptorProto google_protobuf_EnumDescriptorProto;
-struct google_protobuf_EnumDescriptorProto_EnumReservedRange;
-typedef struct google_protobuf_EnumDescriptorProto_EnumReservedRange google_protobuf_EnumDescriptorProto_EnumReservedRange;
-struct google_protobuf_EnumValueDescriptorProto;
-typedef struct google_protobuf_EnumValueDescriptorProto google_protobuf_EnumValueDescriptorProto;
-struct google_protobuf_ServiceDescriptorProto;
-typedef struct google_protobuf_ServiceDescriptorProto google_protobuf_ServiceDescriptorProto;
-struct google_protobuf_MethodDescriptorProto;
-typedef struct google_protobuf_MethodDescriptorProto google_protobuf_MethodDescriptorProto;
-struct google_protobuf_FileOptions;
-typedef struct google_protobuf_FileOptions google_protobuf_FileOptions;
-struct google_protobuf_MessageOptions;
-typedef struct google_protobuf_MessageOptions google_protobuf_MessageOptions;
-struct google_protobuf_FieldOptions;
-typedef struct google_protobuf_FieldOptions google_protobuf_FieldOptions;
-struct google_protobuf_OneofOptions;
-typedef struct google_protobuf_OneofOptions google_protobuf_OneofOptions;
-struct google_protobuf_EnumOptions;
-typedef struct google_protobuf_EnumOptions google_protobuf_EnumOptions;
-struct google_protobuf_EnumValueOptions;
-typedef struct google_protobuf_EnumValueOptions google_protobuf_EnumValueOptions;
-struct google_protobuf_ServiceOptions;
-typedef struct google_protobuf_ServiceOptions google_protobuf_ServiceOptions;
-struct google_protobuf_MethodOptions;
-typedef struct google_protobuf_MethodOptions google_protobuf_MethodOptions;
-struct google_protobuf_UninterpretedOption;
-typedef struct google_protobuf_UninterpretedOption google_protobuf_UninterpretedOption;
-struct google_protobuf_UninterpretedOption_NamePart;
-typedef struct google_protobuf_UninterpretedOption_NamePart google_protobuf_UninterpretedOption_NamePart;
-struct google_protobuf_SourceCodeInfo;
-typedef struct google_protobuf_SourceCodeInfo google_protobuf_SourceCodeInfo;
-struct google_protobuf_SourceCodeInfo_Location;
-typedef struct google_protobuf_SourceCodeInfo_Location google_protobuf_SourceCodeInfo_Location;
-struct google_protobuf_GeneratedCodeInfo;
-typedef struct google_protobuf_GeneratedCodeInfo google_protobuf_GeneratedCodeInfo;
-struct google_protobuf_GeneratedCodeInfo_Annotation;
-typedef struct google_protobuf_GeneratedCodeInfo_Annotation google_protobuf_GeneratedCodeInfo_Annotation;
+typedef struct google_protobuf_FileDescriptorSet { int a; } google_protobuf_FileDescriptorSet;
+typedef struct google_protobuf_FileDescriptorProto { int a; } google_protobuf_FileDescriptorProto;
+typedef struct google_protobuf_DescriptorProto { int a; } google_protobuf_DescriptorProto;
+typedef struct google_protobuf_DescriptorProto_ExtensionRange { int a; } google_protobuf_DescriptorProto_ExtensionRange;
+typedef struct google_protobuf_DescriptorProto_ReservedRange { int a; } google_protobuf_DescriptorProto_ReservedRange;
+typedef struct google_protobuf_ExtensionRangeOptions { int a; } google_protobuf_ExtensionRangeOptions;
+typedef struct google_protobuf_FieldDescriptorProto { int a; } google_protobuf_FieldDescriptorProto;
+typedef struct google_protobuf_OneofDescriptorProto { int a; } google_protobuf_OneofDescriptorProto;
+typedef struct google_protobuf_EnumDescriptorProto { int a; } google_protobuf_EnumDescriptorProto;
+typedef struct google_protobuf_EnumDescriptorProto_EnumReservedRange { int a; } google_protobuf_EnumDescriptorProto_EnumReservedRange;
+typedef struct google_protobuf_EnumValueDescriptorProto { int a; } google_protobuf_EnumValueDescriptorProto;
+typedef struct google_protobuf_ServiceDescriptorProto { int a; } google_protobuf_ServiceDescriptorProto;
+typedef struct google_protobuf_MethodDescriptorProto { int a; } google_protobuf_MethodDescriptorProto;
+typedef struct google_protobuf_FileOptions { int a; } google_protobuf_FileOptions;
+typedef struct google_protobuf_MessageOptions { int a; } google_protobuf_MessageOptions;
+typedef struct google_protobuf_FieldOptions { int a; } google_protobuf_FieldOptions;
+typedef struct google_protobuf_OneofOptions { int a; } google_protobuf_OneofOptions;
+typedef struct google_protobuf_EnumOptions { int a; } google_protobuf_EnumOptions;
+typedef struct google_protobuf_EnumValueOptions { int a; } google_protobuf_EnumValueOptions;
+typedef struct google_protobuf_ServiceOptions { int a; } google_protobuf_ServiceOptions;
+typedef struct google_protobuf_MethodOptions { int a; } google_protobuf_MethodOptions;
+typedef struct google_protobuf_UninterpretedOption { int a; } google_protobuf_UninterpretedOption;
+typedef struct google_protobuf_UninterpretedOption_NamePart { int a; } google_protobuf_UninterpretedOption_NamePart;
+typedef struct google_protobuf_SourceCodeInfo { int a; } google_protobuf_SourceCodeInfo;
+typedef struct google_protobuf_SourceCodeInfo_Location { int a; } google_protobuf_SourceCodeInfo_Location;
+typedef struct google_protobuf_GeneratedCodeInfo { int a; } google_protobuf_GeneratedCodeInfo;
+typedef struct google_protobuf_GeneratedCodeInfo_Annotation { int a; } google_protobuf_GeneratedCodeInfo_Annotation;
 /* Enums */
 
 typedef enum {
@@ -122,9 +96,7 @@ typedef enum {
   google_protobuf_MethodOptions_IDEMPOTENT = 2
 } google_protobuf_MethodOptions_IdempotencyLevel;
 
-struct google_protobuf_FileDescriptorSet {
-  upb_array* file;
-};
+/* google.protobuf.FileDescriptorSet */
 
 extern const upb_msglayout google_protobuf_FileDescriptorSet_msginit;
 UPB_INLINE google_protobuf_FileDescriptorSet *google_protobuf_FileDescriptorSet_new(upb_arena *arena) {
@@ -138,27 +110,12 @@ UPB_INLINE char *google_protobuf_FileDescriptorSet_serialize(const google_protob
   return upb_encode(msg, &google_protobuf_FileDescriptorSet_msginit, arena, len);
 }
 
-struct google_protobuf_FileDescriptorProto {
-  struct {
-    bool name:1;
-    bool package:1;
-    bool syntax:1;
-    bool options:1;
-    bool source_code_info:1;
-  } has;
-  upb_stringview name;
-  upb_stringview package;
-  upb_stringview syntax;
-  google_protobuf_FileOptions* options;
-  google_protobuf_SourceCodeInfo* source_code_info;
-  upb_array* dependency;
-  upb_array* message_type;
-  upb_array* enum_type;
-  upb_array* service;
-  upb_array* extension;
-  upb_array* public_dependency;
-  upb_array* weak_dependency;
-};
+UPB_INLINE const upb_array* google_protobuf_FileDescriptorSet_file(const google_protobuf_FileDescriptorSet *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(0, 0)); }
+
+UPB_INLINE void google_protobuf_FileDescriptorSet_set_file(google_protobuf_FileDescriptorSet *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(0, 0)) = value; }
+
+
+/* google.protobuf.FileDescriptorProto */
 
 extern const upb_msglayout google_protobuf_FileDescriptorProto_msginit;
 UPB_INLINE google_protobuf_FileDescriptorProto *google_protobuf_FileDescriptorProto_new(upb_arena *arena) {
@@ -172,22 +129,34 @@ UPB_INLINE char *google_protobuf_FileDescriptorProto_serialize(const google_prot
   return upb_encode(msg, &google_protobuf_FileDescriptorProto_msginit, arena, len);
 }
 
-struct google_protobuf_DescriptorProto {
-  struct {
-    bool name:1;
-    bool options:1;
-  } has;
-  upb_stringview name;
-  google_protobuf_MessageOptions* options;
-  upb_array* field;
-  upb_array* nested_type;
-  upb_array* enum_type;
-  upb_array* extension_range;
-  upb_array* extension;
-  upb_array* oneof_decl;
-  upb_array* reserved_range;
-  upb_array* reserved_name;
-};
+UPB_INLINE upb_stringview google_protobuf_FileDescriptorProto_name(const google_protobuf_FileDescriptorProto *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)); }
+UPB_INLINE upb_stringview google_protobuf_FileDescriptorProto_package(const google_protobuf_FileDescriptorProto *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(16, 32)); }
+UPB_INLINE const upb_array* google_protobuf_FileDescriptorProto_dependency(const google_protobuf_FileDescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(40, 80)); }
+UPB_INLINE const upb_array* google_protobuf_FileDescriptorProto_message_type(const google_protobuf_FileDescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(44, 88)); }
+UPB_INLINE const upb_array* google_protobuf_FileDescriptorProto_enum_type(const google_protobuf_FileDescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(48, 96)); }
+UPB_INLINE const upb_array* google_protobuf_FileDescriptorProto_service(const google_protobuf_FileDescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(52, 104)); }
+UPB_INLINE const upb_array* google_protobuf_FileDescriptorProto_extension(const google_protobuf_FileDescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(56, 112)); }
+UPB_INLINE const google_protobuf_FileOptions* google_protobuf_FileDescriptorProto_options(const google_protobuf_FileDescriptorProto *msg) { return UPB_FIELD_AT(msg, const google_protobuf_FileOptions*, UPB_SIZE(32, 64)); }
+UPB_INLINE const google_protobuf_SourceCodeInfo* google_protobuf_FileDescriptorProto_source_code_info(const google_protobuf_FileDescriptorProto *msg) { return UPB_FIELD_AT(msg, const google_protobuf_SourceCodeInfo*, UPB_SIZE(36, 72)); }
+UPB_INLINE const upb_array* google_protobuf_FileDescriptorProto_public_dependency(const google_protobuf_FileDescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(60, 120)); }
+UPB_INLINE const upb_array* google_protobuf_FileDescriptorProto_weak_dependency(const google_protobuf_FileDescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(64, 128)); }
+UPB_INLINE upb_stringview google_protobuf_FileDescriptorProto_syntax(const google_protobuf_FileDescriptorProto *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(24, 48)); }
+
+UPB_INLINE void google_protobuf_FileDescriptorProto_set_name(google_protobuf_FileDescriptorProto *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)) = value; }
+UPB_INLINE void google_protobuf_FileDescriptorProto_set_package(google_protobuf_FileDescriptorProto *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(16, 32)) = value; }
+UPB_INLINE void google_protobuf_FileDescriptorProto_set_dependency(google_protobuf_FileDescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(40, 80)) = value; }
+UPB_INLINE void google_protobuf_FileDescriptorProto_set_message_type(google_protobuf_FileDescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(44, 88)) = value; }
+UPB_INLINE void google_protobuf_FileDescriptorProto_set_enum_type(google_protobuf_FileDescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(48, 96)) = value; }
+UPB_INLINE void google_protobuf_FileDescriptorProto_set_service(google_protobuf_FileDescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(52, 104)) = value; }
+UPB_INLINE void google_protobuf_FileDescriptorProto_set_extension(google_protobuf_FileDescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(56, 112)) = value; }
+UPB_INLINE void google_protobuf_FileDescriptorProto_set_options(google_protobuf_FileDescriptorProto *msg, google_protobuf_FileOptions* value) { UPB_FIELD_AT(msg, google_protobuf_FileOptions*, UPB_SIZE(32, 64)) = value; }
+UPB_INLINE void google_protobuf_FileDescriptorProto_set_source_code_info(google_protobuf_FileDescriptorProto *msg, google_protobuf_SourceCodeInfo* value) { UPB_FIELD_AT(msg, google_protobuf_SourceCodeInfo*, UPB_SIZE(36, 72)) = value; }
+UPB_INLINE void google_protobuf_FileDescriptorProto_set_public_dependency(google_protobuf_FileDescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(60, 120)) = value; }
+UPB_INLINE void google_protobuf_FileDescriptorProto_set_weak_dependency(google_protobuf_FileDescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(64, 128)) = value; }
+UPB_INLINE void google_protobuf_FileDescriptorProto_set_syntax(google_protobuf_FileDescriptorProto *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(24, 48)) = value; }
+
+
+/* google.protobuf.DescriptorProto */
 
 extern const upb_msglayout google_protobuf_DescriptorProto_msginit;
 UPB_INLINE google_protobuf_DescriptorProto *google_protobuf_DescriptorProto_new(upb_arena *arena) {
@@ -201,16 +170,30 @@ UPB_INLINE char *google_protobuf_DescriptorProto_serialize(const google_protobuf
   return upb_encode(msg, &google_protobuf_DescriptorProto_msginit, arena, len);
 }
 
-struct google_protobuf_DescriptorProto_ExtensionRange {
-  struct {
-    bool start:1;
-    bool end:1;
-    bool options:1;
-  } has;
-  int32_t start;
-  int32_t end;
-  google_protobuf_ExtensionRangeOptions* options;
-};
+UPB_INLINE upb_stringview google_protobuf_DescriptorProto_name(const google_protobuf_DescriptorProto *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)); }
+UPB_INLINE const upb_array* google_protobuf_DescriptorProto_field(const google_protobuf_DescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(20, 40)); }
+UPB_INLINE const upb_array* google_protobuf_DescriptorProto_nested_type(const google_protobuf_DescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(24, 48)); }
+UPB_INLINE const upb_array* google_protobuf_DescriptorProto_enum_type(const google_protobuf_DescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(28, 56)); }
+UPB_INLINE const upb_array* google_protobuf_DescriptorProto_extension_range(const google_protobuf_DescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(32, 64)); }
+UPB_INLINE const upb_array* google_protobuf_DescriptorProto_extension(const google_protobuf_DescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(36, 72)); }
+UPB_INLINE const google_protobuf_MessageOptions* google_protobuf_DescriptorProto_options(const google_protobuf_DescriptorProto *msg) { return UPB_FIELD_AT(msg, const google_protobuf_MessageOptions*, UPB_SIZE(16, 32)); }
+UPB_INLINE const upb_array* google_protobuf_DescriptorProto_oneof_decl(const google_protobuf_DescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(40, 80)); }
+UPB_INLINE const upb_array* google_protobuf_DescriptorProto_reserved_range(const google_protobuf_DescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(44, 88)); }
+UPB_INLINE const upb_array* google_protobuf_DescriptorProto_reserved_name(const google_protobuf_DescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(48, 96)); }
+
+UPB_INLINE void google_protobuf_DescriptorProto_set_name(google_protobuf_DescriptorProto *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)) = value; }
+UPB_INLINE void google_protobuf_DescriptorProto_set_field(google_protobuf_DescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(20, 40)) = value; }
+UPB_INLINE void google_protobuf_DescriptorProto_set_nested_type(google_protobuf_DescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(24, 48)) = value; }
+UPB_INLINE void google_protobuf_DescriptorProto_set_enum_type(google_protobuf_DescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(28, 56)) = value; }
+UPB_INLINE void google_protobuf_DescriptorProto_set_extension_range(google_protobuf_DescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(32, 64)) = value; }
+UPB_INLINE void google_protobuf_DescriptorProto_set_extension(google_protobuf_DescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(36, 72)) = value; }
+UPB_INLINE void google_protobuf_DescriptorProto_set_options(google_protobuf_DescriptorProto *msg, google_protobuf_MessageOptions* value) { UPB_FIELD_AT(msg, google_protobuf_MessageOptions*, UPB_SIZE(16, 32)) = value; }
+UPB_INLINE void google_protobuf_DescriptorProto_set_oneof_decl(google_protobuf_DescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(40, 80)) = value; }
+UPB_INLINE void google_protobuf_DescriptorProto_set_reserved_range(google_protobuf_DescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(44, 88)) = value; }
+UPB_INLINE void google_protobuf_DescriptorProto_set_reserved_name(google_protobuf_DescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(48, 96)) = value; }
+
+
+/* google.protobuf.DescriptorProto.ExtensionRange */
 
 extern const upb_msglayout google_protobuf_DescriptorProto_ExtensionRange_msginit;
 UPB_INLINE google_protobuf_DescriptorProto_ExtensionRange *google_protobuf_DescriptorProto_ExtensionRange_new(upb_arena *arena) {
@@ -224,14 +207,16 @@ UPB_INLINE char *google_protobuf_DescriptorProto_ExtensionRange_serialize(const 
   return upb_encode(msg, &google_protobuf_DescriptorProto_ExtensionRange_msginit, arena, len);
 }
 
-struct google_protobuf_DescriptorProto_ReservedRange {
-  struct {
-    bool start:1;
-    bool end:1;
-  } has;
-  int32_t start;
-  int32_t end;
-};
+UPB_INLINE int32_t google_protobuf_DescriptorProto_ExtensionRange_start(const google_protobuf_DescriptorProto_ExtensionRange *msg) { return UPB_FIELD_AT(msg, int32_t, UPB_SIZE(4, 4)); }
+UPB_INLINE int32_t google_protobuf_DescriptorProto_ExtensionRange_end(const google_protobuf_DescriptorProto_ExtensionRange *msg) { return UPB_FIELD_AT(msg, int32_t, UPB_SIZE(8, 8)); }
+UPB_INLINE const google_protobuf_ExtensionRangeOptions* google_protobuf_DescriptorProto_ExtensionRange_options(const google_protobuf_DescriptorProto_ExtensionRange *msg) { return UPB_FIELD_AT(msg, const google_protobuf_ExtensionRangeOptions*, UPB_SIZE(12, 16)); }
+
+UPB_INLINE void google_protobuf_DescriptorProto_ExtensionRange_set_start(google_protobuf_DescriptorProto_ExtensionRange *msg, int32_t value) { UPB_FIELD_AT(msg, int32_t, UPB_SIZE(4, 4)) = value; }
+UPB_INLINE void google_protobuf_DescriptorProto_ExtensionRange_set_end(google_protobuf_DescriptorProto_ExtensionRange *msg, int32_t value) { UPB_FIELD_AT(msg, int32_t, UPB_SIZE(8, 8)) = value; }
+UPB_INLINE void google_protobuf_DescriptorProto_ExtensionRange_set_options(google_protobuf_DescriptorProto_ExtensionRange *msg, google_protobuf_ExtensionRangeOptions* value) { UPB_FIELD_AT(msg, google_protobuf_ExtensionRangeOptions*, UPB_SIZE(12, 16)) = value; }
+
+
+/* google.protobuf.DescriptorProto.ReservedRange */
 
 extern const upb_msglayout google_protobuf_DescriptorProto_ReservedRange_msginit;
 UPB_INLINE google_protobuf_DescriptorProto_ReservedRange *google_protobuf_DescriptorProto_ReservedRange_new(upb_arena *arena) {
@@ -245,9 +230,14 @@ UPB_INLINE char *google_protobuf_DescriptorProto_ReservedRange_serialize(const g
   return upb_encode(msg, &google_protobuf_DescriptorProto_ReservedRange_msginit, arena, len);
 }
 
-struct google_protobuf_ExtensionRangeOptions {
-  upb_array* uninterpreted_option;
-};
+UPB_INLINE int32_t google_protobuf_DescriptorProto_ReservedRange_start(const google_protobuf_DescriptorProto_ReservedRange *msg) { return UPB_FIELD_AT(msg, int32_t, UPB_SIZE(4, 4)); }
+UPB_INLINE int32_t google_protobuf_DescriptorProto_ReservedRange_end(const google_protobuf_DescriptorProto_ReservedRange *msg) { return UPB_FIELD_AT(msg, int32_t, UPB_SIZE(8, 8)); }
+
+UPB_INLINE void google_protobuf_DescriptorProto_ReservedRange_set_start(google_protobuf_DescriptorProto_ReservedRange *msg, int32_t value) { UPB_FIELD_AT(msg, int32_t, UPB_SIZE(4, 4)) = value; }
+UPB_INLINE void google_protobuf_DescriptorProto_ReservedRange_set_end(google_protobuf_DescriptorProto_ReservedRange *msg, int32_t value) { UPB_FIELD_AT(msg, int32_t, UPB_SIZE(8, 8)) = value; }
+
+
+/* google.protobuf.ExtensionRangeOptions */
 
 extern const upb_msglayout google_protobuf_ExtensionRangeOptions_msginit;
 UPB_INLINE google_protobuf_ExtensionRangeOptions *google_protobuf_ExtensionRangeOptions_new(upb_arena *arena) {
@@ -261,30 +251,12 @@ UPB_INLINE char *google_protobuf_ExtensionRangeOptions_serialize(const google_pr
   return upb_encode(msg, &google_protobuf_ExtensionRangeOptions_msginit, arena, len);
 }
 
-struct google_protobuf_FieldDescriptorProto {
-  struct {
-    bool label:1;
-    bool type:1;
-    bool number:1;
-    bool oneof_index:1;
-    bool name:1;
-    bool extendee:1;
-    bool type_name:1;
-    bool default_value:1;
-    bool json_name:1;
-    bool options:1;
-  } has;
-  google_protobuf_FieldDescriptorProto_Label label;
-  google_protobuf_FieldDescriptorProto_Type type;
-  int32_t number;
-  int32_t oneof_index;
-  upb_stringview name;
-  upb_stringview extendee;
-  upb_stringview type_name;
-  upb_stringview default_value;
-  upb_stringview json_name;
-  google_protobuf_FieldOptions* options;
-};
+UPB_INLINE const upb_array* google_protobuf_ExtensionRangeOptions_uninterpreted_option(const google_protobuf_ExtensionRangeOptions *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(0, 0)); }
+
+UPB_INLINE void google_protobuf_ExtensionRangeOptions_set_uninterpreted_option(google_protobuf_ExtensionRangeOptions *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(0, 0)) = value; }
+
+
+/* google.protobuf.FieldDescriptorProto */
 
 extern const upb_msglayout google_protobuf_FieldDescriptorProto_msginit;
 UPB_INLINE google_protobuf_FieldDescriptorProto *google_protobuf_FieldDescriptorProto_new(upb_arena *arena) {
@@ -298,14 +270,30 @@ UPB_INLINE char *google_protobuf_FieldDescriptorProto_serialize(const google_pro
   return upb_encode(msg, &google_protobuf_FieldDescriptorProto_msginit, arena, len);
 }
 
-struct google_protobuf_OneofDescriptorProto {
-  struct {
-    bool name:1;
-    bool options:1;
-  } has;
-  upb_stringview name;
-  google_protobuf_OneofOptions* options;
-};
+UPB_INLINE upb_stringview google_protobuf_FieldDescriptorProto_name(const google_protobuf_FieldDescriptorProto *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(32, 32)); }
+UPB_INLINE upb_stringview google_protobuf_FieldDescriptorProto_extendee(const google_protobuf_FieldDescriptorProto *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(40, 48)); }
+UPB_INLINE int32_t google_protobuf_FieldDescriptorProto_number(const google_protobuf_FieldDescriptorProto *msg) { return UPB_FIELD_AT(msg, int32_t, UPB_SIZE(24, 24)); }
+UPB_INLINE google_protobuf_FieldDescriptorProto_Label google_protobuf_FieldDescriptorProto_label(const google_protobuf_FieldDescriptorProto *msg) { return UPB_FIELD_AT(msg, google_protobuf_FieldDescriptorProto_Label, UPB_SIZE(8, 8)); }
+UPB_INLINE google_protobuf_FieldDescriptorProto_Type google_protobuf_FieldDescriptorProto_type(const google_protobuf_FieldDescriptorProto *msg) { return UPB_FIELD_AT(msg, google_protobuf_FieldDescriptorProto_Type, UPB_SIZE(16, 16)); }
+UPB_INLINE upb_stringview google_protobuf_FieldDescriptorProto_type_name(const google_protobuf_FieldDescriptorProto *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(48, 64)); }
+UPB_INLINE upb_stringview google_protobuf_FieldDescriptorProto_default_value(const google_protobuf_FieldDescriptorProto *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(56, 80)); }
+UPB_INLINE const google_protobuf_FieldOptions* google_protobuf_FieldDescriptorProto_options(const google_protobuf_FieldDescriptorProto *msg) { return UPB_FIELD_AT(msg, const google_protobuf_FieldOptions*, UPB_SIZE(72, 112)); }
+UPB_INLINE int32_t google_protobuf_FieldDescriptorProto_oneof_index(const google_protobuf_FieldDescriptorProto *msg) { return UPB_FIELD_AT(msg, int32_t, UPB_SIZE(28, 28)); }
+UPB_INLINE upb_stringview google_protobuf_FieldDescriptorProto_json_name(const google_protobuf_FieldDescriptorProto *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(64, 96)); }
+
+UPB_INLINE void google_protobuf_FieldDescriptorProto_set_name(google_protobuf_FieldDescriptorProto *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(32, 32)) = value; }
+UPB_INLINE void google_protobuf_FieldDescriptorProto_set_extendee(google_protobuf_FieldDescriptorProto *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(40, 48)) = value; }
+UPB_INLINE void google_protobuf_FieldDescriptorProto_set_number(google_protobuf_FieldDescriptorProto *msg, int32_t value) { UPB_FIELD_AT(msg, int32_t, UPB_SIZE(24, 24)) = value; }
+UPB_INLINE void google_protobuf_FieldDescriptorProto_set_label(google_protobuf_FieldDescriptorProto *msg, google_protobuf_FieldDescriptorProto_Label value) { UPB_FIELD_AT(msg, google_protobuf_FieldDescriptorProto_Label, UPB_SIZE(8, 8)) = value; }
+UPB_INLINE void google_protobuf_FieldDescriptorProto_set_type(google_protobuf_FieldDescriptorProto *msg, google_protobuf_FieldDescriptorProto_Type value) { UPB_FIELD_AT(msg, google_protobuf_FieldDescriptorProto_Type, UPB_SIZE(16, 16)) = value; }
+UPB_INLINE void google_protobuf_FieldDescriptorProto_set_type_name(google_protobuf_FieldDescriptorProto *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(48, 64)) = value; }
+UPB_INLINE void google_protobuf_FieldDescriptorProto_set_default_value(google_protobuf_FieldDescriptorProto *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(56, 80)) = value; }
+UPB_INLINE void google_protobuf_FieldDescriptorProto_set_options(google_protobuf_FieldDescriptorProto *msg, google_protobuf_FieldOptions* value) { UPB_FIELD_AT(msg, google_protobuf_FieldOptions*, UPB_SIZE(72, 112)) = value; }
+UPB_INLINE void google_protobuf_FieldDescriptorProto_set_oneof_index(google_protobuf_FieldDescriptorProto *msg, int32_t value) { UPB_FIELD_AT(msg, int32_t, UPB_SIZE(28, 28)) = value; }
+UPB_INLINE void google_protobuf_FieldDescriptorProto_set_json_name(google_protobuf_FieldDescriptorProto *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(64, 96)) = value; }
+
+
+/* google.protobuf.OneofDescriptorProto */
 
 extern const upb_msglayout google_protobuf_OneofDescriptorProto_msginit;
 UPB_INLINE google_protobuf_OneofDescriptorProto *google_protobuf_OneofDescriptorProto_new(upb_arena *arena) {
@@ -319,17 +307,14 @@ UPB_INLINE char *google_protobuf_OneofDescriptorProto_serialize(const google_pro
   return upb_encode(msg, &google_protobuf_OneofDescriptorProto_msginit, arena, len);
 }
 
-struct google_protobuf_EnumDescriptorProto {
-  struct {
-    bool name:1;
-    bool options:1;
-  } has;
-  upb_stringview name;
-  google_protobuf_EnumOptions* options;
-  upb_array* value;
-  upb_array* reserved_range;
-  upb_array* reserved_name;
-};
+UPB_INLINE upb_stringview google_protobuf_OneofDescriptorProto_name(const google_protobuf_OneofDescriptorProto *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)); }
+UPB_INLINE const google_protobuf_OneofOptions* google_protobuf_OneofDescriptorProto_options(const google_protobuf_OneofDescriptorProto *msg) { return UPB_FIELD_AT(msg, const google_protobuf_OneofOptions*, UPB_SIZE(16, 32)); }
+
+UPB_INLINE void google_protobuf_OneofDescriptorProto_set_name(google_protobuf_OneofDescriptorProto *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)) = value; }
+UPB_INLINE void google_protobuf_OneofDescriptorProto_set_options(google_protobuf_OneofDescriptorProto *msg, google_protobuf_OneofOptions* value) { UPB_FIELD_AT(msg, google_protobuf_OneofOptions*, UPB_SIZE(16, 32)) = value; }
+
+
+/* google.protobuf.EnumDescriptorProto */
 
 extern const upb_msglayout google_protobuf_EnumDescriptorProto_msginit;
 UPB_INLINE google_protobuf_EnumDescriptorProto *google_protobuf_EnumDescriptorProto_new(upb_arena *arena) {
@@ -343,14 +328,20 @@ UPB_INLINE char *google_protobuf_EnumDescriptorProto_serialize(const google_prot
   return upb_encode(msg, &google_protobuf_EnumDescriptorProto_msginit, arena, len);
 }
 
-struct google_protobuf_EnumDescriptorProto_EnumReservedRange {
-  struct {
-    bool start:1;
-    bool end:1;
-  } has;
-  int32_t start;
-  int32_t end;
-};
+UPB_INLINE upb_stringview google_protobuf_EnumDescriptorProto_name(const google_protobuf_EnumDescriptorProto *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)); }
+UPB_INLINE const upb_array* google_protobuf_EnumDescriptorProto_value(const google_protobuf_EnumDescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(20, 40)); }
+UPB_INLINE const google_protobuf_EnumOptions* google_protobuf_EnumDescriptorProto_options(const google_protobuf_EnumDescriptorProto *msg) { return UPB_FIELD_AT(msg, const google_protobuf_EnumOptions*, UPB_SIZE(16, 32)); }
+UPB_INLINE const upb_array* google_protobuf_EnumDescriptorProto_reserved_range(const google_protobuf_EnumDescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(24, 48)); }
+UPB_INLINE const upb_array* google_protobuf_EnumDescriptorProto_reserved_name(const google_protobuf_EnumDescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(28, 56)); }
+
+UPB_INLINE void google_protobuf_EnumDescriptorProto_set_name(google_protobuf_EnumDescriptorProto *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)) = value; }
+UPB_INLINE void google_protobuf_EnumDescriptorProto_set_value(google_protobuf_EnumDescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(20, 40)) = value; }
+UPB_INLINE void google_protobuf_EnumDescriptorProto_set_options(google_protobuf_EnumDescriptorProto *msg, google_protobuf_EnumOptions* value) { UPB_FIELD_AT(msg, google_protobuf_EnumOptions*, UPB_SIZE(16, 32)) = value; }
+UPB_INLINE void google_protobuf_EnumDescriptorProto_set_reserved_range(google_protobuf_EnumDescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(24, 48)) = value; }
+UPB_INLINE void google_protobuf_EnumDescriptorProto_set_reserved_name(google_protobuf_EnumDescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(28, 56)) = value; }
+
+
+/* google.protobuf.EnumDescriptorProto.EnumReservedRange */
 
 extern const upb_msglayout google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit;
 UPB_INLINE google_protobuf_EnumDescriptorProto_EnumReservedRange *google_protobuf_EnumDescriptorProto_EnumReservedRange_new(upb_arena *arena) {
@@ -364,16 +355,14 @@ UPB_INLINE char *google_protobuf_EnumDescriptorProto_EnumReservedRange_serialize
   return upb_encode(msg, &google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit, arena, len);
 }
 
-struct google_protobuf_EnumValueDescriptorProto {
-  struct {
-    bool number:1;
-    bool name:1;
-    bool options:1;
-  } has;
-  int32_t number;
-  upb_stringview name;
-  google_protobuf_EnumValueOptions* options;
-};
+UPB_INLINE int32_t google_protobuf_EnumDescriptorProto_EnumReservedRange_start(const google_protobuf_EnumDescriptorProto_EnumReservedRange *msg) { return UPB_FIELD_AT(msg, int32_t, UPB_SIZE(4, 4)); }
+UPB_INLINE int32_t google_protobuf_EnumDescriptorProto_EnumReservedRange_end(const google_protobuf_EnumDescriptorProto_EnumReservedRange *msg) { return UPB_FIELD_AT(msg, int32_t, UPB_SIZE(8, 8)); }
+
+UPB_INLINE void google_protobuf_EnumDescriptorProto_EnumReservedRange_set_start(google_protobuf_EnumDescriptorProto_EnumReservedRange *msg, int32_t value) { UPB_FIELD_AT(msg, int32_t, UPB_SIZE(4, 4)) = value; }
+UPB_INLINE void google_protobuf_EnumDescriptorProto_EnumReservedRange_set_end(google_protobuf_EnumDescriptorProto_EnumReservedRange *msg, int32_t value) { UPB_FIELD_AT(msg, int32_t, UPB_SIZE(8, 8)) = value; }
+
+
+/* google.protobuf.EnumValueDescriptorProto */
 
 extern const upb_msglayout google_protobuf_EnumValueDescriptorProto_msginit;
 UPB_INLINE google_protobuf_EnumValueDescriptorProto *google_protobuf_EnumValueDescriptorProto_new(upb_arena *arena) {
@@ -387,15 +376,16 @@ UPB_INLINE char *google_protobuf_EnumValueDescriptorProto_serialize(const google
   return upb_encode(msg, &google_protobuf_EnumValueDescriptorProto_msginit, arena, len);
 }
 
-struct google_protobuf_ServiceDescriptorProto {
-  struct {
-    bool name:1;
-    bool options:1;
-  } has;
-  upb_stringview name;
-  google_protobuf_ServiceOptions* options;
-  upb_array* method;
-};
+UPB_INLINE upb_stringview google_protobuf_EnumValueDescriptorProto_name(const google_protobuf_EnumValueDescriptorProto *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)); }
+UPB_INLINE int32_t google_protobuf_EnumValueDescriptorProto_number(const google_protobuf_EnumValueDescriptorProto *msg) { return UPB_FIELD_AT(msg, int32_t, UPB_SIZE(4, 4)); }
+UPB_INLINE const google_protobuf_EnumValueOptions* google_protobuf_EnumValueDescriptorProto_options(const google_protobuf_EnumValueDescriptorProto *msg) { return UPB_FIELD_AT(msg, const google_protobuf_EnumValueOptions*, UPB_SIZE(16, 32)); }
+
+UPB_INLINE void google_protobuf_EnumValueDescriptorProto_set_name(google_protobuf_EnumValueDescriptorProto *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)) = value; }
+UPB_INLINE void google_protobuf_EnumValueDescriptorProto_set_number(google_protobuf_EnumValueDescriptorProto *msg, int32_t value) { UPB_FIELD_AT(msg, int32_t, UPB_SIZE(4, 4)) = value; }
+UPB_INLINE void google_protobuf_EnumValueDescriptorProto_set_options(google_protobuf_EnumValueDescriptorProto *msg, google_protobuf_EnumValueOptions* value) { UPB_FIELD_AT(msg, google_protobuf_EnumValueOptions*, UPB_SIZE(16, 32)) = value; }
+
+
+/* google.protobuf.ServiceDescriptorProto */
 
 extern const upb_msglayout google_protobuf_ServiceDescriptorProto_msginit;
 UPB_INLINE google_protobuf_ServiceDescriptorProto *google_protobuf_ServiceDescriptorProto_new(upb_arena *arena) {
@@ -409,22 +399,16 @@ UPB_INLINE char *google_protobuf_ServiceDescriptorProto_serialize(const google_p
   return upb_encode(msg, &google_protobuf_ServiceDescriptorProto_msginit, arena, len);
 }
 
-struct google_protobuf_MethodDescriptorProto {
-  struct {
-    bool client_streaming:1;
-    bool server_streaming:1;
-    bool name:1;
-    bool input_type:1;
-    bool output_type:1;
-    bool options:1;
-  } has;
-  bool client_streaming;
-  bool server_streaming;
-  upb_stringview name;
-  upb_stringview input_type;
-  upb_stringview output_type;
-  google_protobuf_MethodOptions* options;
-};
+UPB_INLINE upb_stringview google_protobuf_ServiceDescriptorProto_name(const google_protobuf_ServiceDescriptorProto *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)); }
+UPB_INLINE const upb_array* google_protobuf_ServiceDescriptorProto_method(const google_protobuf_ServiceDescriptorProto *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(20, 40)); }
+UPB_INLINE const google_protobuf_ServiceOptions* google_protobuf_ServiceDescriptorProto_options(const google_protobuf_ServiceDescriptorProto *msg) { return UPB_FIELD_AT(msg, const google_protobuf_ServiceOptions*, UPB_SIZE(16, 32)); }
+
+UPB_INLINE void google_protobuf_ServiceDescriptorProto_set_name(google_protobuf_ServiceDescriptorProto *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)) = value; }
+UPB_INLINE void google_protobuf_ServiceDescriptorProto_set_method(google_protobuf_ServiceDescriptorProto *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(20, 40)) = value; }
+UPB_INLINE void google_protobuf_ServiceDescriptorProto_set_options(google_protobuf_ServiceDescriptorProto *msg, google_protobuf_ServiceOptions* value) { UPB_FIELD_AT(msg, google_protobuf_ServiceOptions*, UPB_SIZE(16, 32)) = value; }
+
+
+/* google.protobuf.MethodDescriptorProto */
 
 extern const upb_msglayout google_protobuf_MethodDescriptorProto_msginit;
 UPB_INLINE google_protobuf_MethodDescriptorProto *google_protobuf_MethodDescriptorProto_new(upb_arena *arena) {
@@ -438,47 +422,22 @@ UPB_INLINE char *google_protobuf_MethodDescriptorProto_serialize(const google_pr
   return upb_encode(msg, &google_protobuf_MethodDescriptorProto_msginit, arena, len);
 }
 
-struct google_protobuf_FileOptions {
-  struct {
-    bool optimize_for:1;
-    bool java_multiple_files:1;
-    bool cc_generic_services:1;
-    bool java_generic_services:1;
-    bool py_generic_services:1;
-    bool java_generate_equals_and_hash:1;
-    bool deprecated:1;
-    bool java_string_check_utf8:1;
-    bool cc_enable_arenas:1;
-    bool php_generic_services:1;
-    bool java_package:1;
-    bool java_outer_classname:1;
-    bool go_package:1;
-    bool objc_class_prefix:1;
-    bool csharp_namespace:1;
-    bool swift_prefix:1;
-    bool php_class_prefix:1;
-    bool php_namespace:1;
-  } has;
-  google_protobuf_FileOptions_OptimizeMode optimize_for;
-  bool java_multiple_files;
-  bool cc_generic_services;
-  bool java_generic_services;
-  bool py_generic_services;
-  bool java_generate_equals_and_hash;
-  bool deprecated;
-  bool java_string_check_utf8;
-  bool cc_enable_arenas;
-  bool php_generic_services;
-  upb_stringview java_package;
-  upb_stringview java_outer_classname;
-  upb_stringview go_package;
-  upb_stringview objc_class_prefix;
-  upb_stringview csharp_namespace;
-  upb_stringview swift_prefix;
-  upb_stringview php_class_prefix;
-  upb_stringview php_namespace;
-  upb_array* uninterpreted_option;
-};
+UPB_INLINE upb_stringview google_protobuf_MethodDescriptorProto_name(const google_protobuf_MethodDescriptorProto *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)); }
+UPB_INLINE upb_stringview google_protobuf_MethodDescriptorProto_input_type(const google_protobuf_MethodDescriptorProto *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(16, 32)); }
+UPB_INLINE upb_stringview google_protobuf_MethodDescriptorProto_output_type(const google_protobuf_MethodDescriptorProto *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(24, 48)); }
+UPB_INLINE const google_protobuf_MethodOptions* google_protobuf_MethodDescriptorProto_options(const google_protobuf_MethodDescriptorProto *msg) { return UPB_FIELD_AT(msg, const google_protobuf_MethodOptions*, UPB_SIZE(32, 64)); }
+UPB_INLINE bool google_protobuf_MethodDescriptorProto_client_streaming(const google_protobuf_MethodDescriptorProto *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(1, 1)); }
+UPB_INLINE bool google_protobuf_MethodDescriptorProto_server_streaming(const google_protobuf_MethodDescriptorProto *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(2, 2)); }
+
+UPB_INLINE void google_protobuf_MethodDescriptorProto_set_name(google_protobuf_MethodDescriptorProto *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)) = value; }
+UPB_INLINE void google_protobuf_MethodDescriptorProto_set_input_type(google_protobuf_MethodDescriptorProto *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(16, 32)) = value; }
+UPB_INLINE void google_protobuf_MethodDescriptorProto_set_output_type(google_protobuf_MethodDescriptorProto *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(24, 48)) = value; }
+UPB_INLINE void google_protobuf_MethodDescriptorProto_set_options(google_protobuf_MethodDescriptorProto *msg, google_protobuf_MethodOptions* value) { UPB_FIELD_AT(msg, google_protobuf_MethodOptions*, UPB_SIZE(32, 64)) = value; }
+UPB_INLINE void google_protobuf_MethodDescriptorProto_set_client_streaming(google_protobuf_MethodDescriptorProto *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(1, 1)) = value; }
+UPB_INLINE void google_protobuf_MethodDescriptorProto_set_server_streaming(google_protobuf_MethodDescriptorProto *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(2, 2)) = value; }
+
+
+/* google.protobuf.FileOptions */
 
 extern const upb_msglayout google_protobuf_FileOptions_msginit;
 UPB_INLINE google_protobuf_FileOptions *google_protobuf_FileOptions_new(upb_arena *arena) {
@@ -492,19 +451,48 @@ UPB_INLINE char *google_protobuf_FileOptions_serialize(const google_protobuf_Fil
   return upb_encode(msg, &google_protobuf_FileOptions_msginit, arena, len);
 }
 
-struct google_protobuf_MessageOptions {
-  struct {
-    bool message_set_wire_format:1;
-    bool no_standard_descriptor_accessor:1;
-    bool deprecated:1;
-    bool map_entry:1;
-  } has;
-  bool message_set_wire_format;
-  bool no_standard_descriptor_accessor;
-  bool deprecated;
-  bool map_entry;
-  upb_array* uninterpreted_option;
-};
+UPB_INLINE upb_stringview google_protobuf_FileOptions_java_package(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(32, 32)); }
+UPB_INLINE upb_stringview google_protobuf_FileOptions_java_outer_classname(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(40, 48)); }
+UPB_INLINE google_protobuf_FileOptions_OptimizeMode google_protobuf_FileOptions_optimize_for(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, google_protobuf_FileOptions_OptimizeMode, UPB_SIZE(8, 8)); }
+UPB_INLINE bool google_protobuf_FileOptions_java_multiple_files(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(16, 16)); }
+UPB_INLINE upb_stringview google_protobuf_FileOptions_go_package(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(48, 64)); }
+UPB_INLINE bool google_protobuf_FileOptions_cc_generic_services(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(17, 17)); }
+UPB_INLINE bool google_protobuf_FileOptions_java_generic_services(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(18, 18)); }
+UPB_INLINE bool google_protobuf_FileOptions_py_generic_services(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(19, 19)); }
+UPB_INLINE bool google_protobuf_FileOptions_java_generate_equals_and_hash(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(20, 20)); }
+UPB_INLINE bool google_protobuf_FileOptions_deprecated(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(21, 21)); }
+UPB_INLINE bool google_protobuf_FileOptions_java_string_check_utf8(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(22, 22)); }
+UPB_INLINE bool google_protobuf_FileOptions_cc_enable_arenas(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(23, 23)); }
+UPB_INLINE upb_stringview google_protobuf_FileOptions_objc_class_prefix(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(56, 80)); }
+UPB_INLINE upb_stringview google_protobuf_FileOptions_csharp_namespace(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(64, 96)); }
+UPB_INLINE upb_stringview google_protobuf_FileOptions_swift_prefix(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(72, 112)); }
+UPB_INLINE upb_stringview google_protobuf_FileOptions_php_class_prefix(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(80, 128)); }
+UPB_INLINE upb_stringview google_protobuf_FileOptions_php_namespace(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(88, 144)); }
+UPB_INLINE bool google_protobuf_FileOptions_php_generic_services(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(24, 24)); }
+UPB_INLINE const upb_array* google_protobuf_FileOptions_uninterpreted_option(const google_protobuf_FileOptions *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(96, 160)); }
+
+UPB_INLINE void google_protobuf_FileOptions_set_java_package(google_protobuf_FileOptions *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(32, 32)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_java_outer_classname(google_protobuf_FileOptions *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(40, 48)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_optimize_for(google_protobuf_FileOptions *msg, google_protobuf_FileOptions_OptimizeMode value) { UPB_FIELD_AT(msg, google_protobuf_FileOptions_OptimizeMode, UPB_SIZE(8, 8)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_java_multiple_files(google_protobuf_FileOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(16, 16)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_go_package(google_protobuf_FileOptions *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(48, 64)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_cc_generic_services(google_protobuf_FileOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(17, 17)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_java_generic_services(google_protobuf_FileOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(18, 18)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_py_generic_services(google_protobuf_FileOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(19, 19)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_java_generate_equals_and_hash(google_protobuf_FileOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(20, 20)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_deprecated(google_protobuf_FileOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(21, 21)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_java_string_check_utf8(google_protobuf_FileOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(22, 22)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_cc_enable_arenas(google_protobuf_FileOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(23, 23)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_objc_class_prefix(google_protobuf_FileOptions *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(56, 80)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_csharp_namespace(google_protobuf_FileOptions *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(64, 96)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_swift_prefix(google_protobuf_FileOptions *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(72, 112)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_php_class_prefix(google_protobuf_FileOptions *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(80, 128)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_php_namespace(google_protobuf_FileOptions *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(88, 144)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_php_generic_services(google_protobuf_FileOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(24, 24)) = value; }
+UPB_INLINE void google_protobuf_FileOptions_set_uninterpreted_option(google_protobuf_FileOptions *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(96, 160)) = value; }
+
+
+/* google.protobuf.MessageOptions */
 
 extern const upb_msglayout google_protobuf_MessageOptions_msginit;
 UPB_INLINE google_protobuf_MessageOptions *google_protobuf_MessageOptions_new(upb_arena *arena) {
@@ -518,23 +506,20 @@ UPB_INLINE char *google_protobuf_MessageOptions_serialize(const google_protobuf_
   return upb_encode(msg, &google_protobuf_MessageOptions_msginit, arena, len);
 }
 
-struct google_protobuf_FieldOptions {
-  struct {
-    bool ctype:1;
-    bool jstype:1;
-    bool packed:1;
-    bool deprecated:1;
-    bool lazy:1;
-    bool weak:1;
-  } has;
-  google_protobuf_FieldOptions_CType ctype;
-  google_protobuf_FieldOptions_JSType jstype;
-  bool packed;
-  bool deprecated;
-  bool lazy;
-  bool weak;
-  upb_array* uninterpreted_option;
-};
+UPB_INLINE bool google_protobuf_MessageOptions_message_set_wire_format(const google_protobuf_MessageOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(1, 1)); }
+UPB_INLINE bool google_protobuf_MessageOptions_no_standard_descriptor_accessor(const google_protobuf_MessageOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(2, 2)); }
+UPB_INLINE bool google_protobuf_MessageOptions_deprecated(const google_protobuf_MessageOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(3, 3)); }
+UPB_INLINE bool google_protobuf_MessageOptions_map_entry(const google_protobuf_MessageOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(4, 4)); }
+UPB_INLINE const upb_array* google_protobuf_MessageOptions_uninterpreted_option(const google_protobuf_MessageOptions *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(8, 8)); }
+
+UPB_INLINE void google_protobuf_MessageOptions_set_message_set_wire_format(google_protobuf_MessageOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(1, 1)) = value; }
+UPB_INLINE void google_protobuf_MessageOptions_set_no_standard_descriptor_accessor(google_protobuf_MessageOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(2, 2)) = value; }
+UPB_INLINE void google_protobuf_MessageOptions_set_deprecated(google_protobuf_MessageOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(3, 3)) = value; }
+UPB_INLINE void google_protobuf_MessageOptions_set_map_entry(google_protobuf_MessageOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(4, 4)) = value; }
+UPB_INLINE void google_protobuf_MessageOptions_set_uninterpreted_option(google_protobuf_MessageOptions *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(8, 8)) = value; }
+
+
+/* google.protobuf.FieldOptions */
 
 extern const upb_msglayout google_protobuf_FieldOptions_msginit;
 UPB_INLINE google_protobuf_FieldOptions *google_protobuf_FieldOptions_new(upb_arena *arena) {
@@ -548,9 +533,24 @@ UPB_INLINE char *google_protobuf_FieldOptions_serialize(const google_protobuf_Fi
   return upb_encode(msg, &google_protobuf_FieldOptions_msginit, arena, len);
 }
 
-struct google_protobuf_OneofOptions {
-  upb_array* uninterpreted_option;
-};
+UPB_INLINE google_protobuf_FieldOptions_CType google_protobuf_FieldOptions_ctype(const google_protobuf_FieldOptions *msg) { return UPB_FIELD_AT(msg, google_protobuf_FieldOptions_CType, UPB_SIZE(8, 8)); }
+UPB_INLINE bool google_protobuf_FieldOptions_packed(const google_protobuf_FieldOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(24, 24)); }
+UPB_INLINE bool google_protobuf_FieldOptions_deprecated(const google_protobuf_FieldOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(25, 25)); }
+UPB_INLINE bool google_protobuf_FieldOptions_lazy(const google_protobuf_FieldOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(26, 26)); }
+UPB_INLINE google_protobuf_FieldOptions_JSType google_protobuf_FieldOptions_jstype(const google_protobuf_FieldOptions *msg) { return UPB_FIELD_AT(msg, google_protobuf_FieldOptions_JSType, UPB_SIZE(16, 16)); }
+UPB_INLINE bool google_protobuf_FieldOptions_weak(const google_protobuf_FieldOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(27, 27)); }
+UPB_INLINE const upb_array* google_protobuf_FieldOptions_uninterpreted_option(const google_protobuf_FieldOptions *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(28, 32)); }
+
+UPB_INLINE void google_protobuf_FieldOptions_set_ctype(google_protobuf_FieldOptions *msg, google_protobuf_FieldOptions_CType value) { UPB_FIELD_AT(msg, google_protobuf_FieldOptions_CType, UPB_SIZE(8, 8)) = value; }
+UPB_INLINE void google_protobuf_FieldOptions_set_packed(google_protobuf_FieldOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(24, 24)) = value; }
+UPB_INLINE void google_protobuf_FieldOptions_set_deprecated(google_protobuf_FieldOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(25, 25)) = value; }
+UPB_INLINE void google_protobuf_FieldOptions_set_lazy(google_protobuf_FieldOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(26, 26)) = value; }
+UPB_INLINE void google_protobuf_FieldOptions_set_jstype(google_protobuf_FieldOptions *msg, google_protobuf_FieldOptions_JSType value) { UPB_FIELD_AT(msg, google_protobuf_FieldOptions_JSType, UPB_SIZE(16, 16)) = value; }
+UPB_INLINE void google_protobuf_FieldOptions_set_weak(google_protobuf_FieldOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(27, 27)) = value; }
+UPB_INLINE void google_protobuf_FieldOptions_set_uninterpreted_option(google_protobuf_FieldOptions *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(28, 32)) = value; }
+
+
+/* google.protobuf.OneofOptions */
 
 extern const upb_msglayout google_protobuf_OneofOptions_msginit;
 UPB_INLINE google_protobuf_OneofOptions *google_protobuf_OneofOptions_new(upb_arena *arena) {
@@ -564,15 +564,12 @@ UPB_INLINE char *google_protobuf_OneofOptions_serialize(const google_protobuf_On
   return upb_encode(msg, &google_protobuf_OneofOptions_msginit, arena, len);
 }
 
-struct google_protobuf_EnumOptions {
-  struct {
-    bool allow_alias:1;
-    bool deprecated:1;
-  } has;
-  bool allow_alias;
-  bool deprecated;
-  upb_array* uninterpreted_option;
-};
+UPB_INLINE const upb_array* google_protobuf_OneofOptions_uninterpreted_option(const google_protobuf_OneofOptions *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(0, 0)); }
+
+UPB_INLINE void google_protobuf_OneofOptions_set_uninterpreted_option(google_protobuf_OneofOptions *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(0, 0)) = value; }
+
+
+/* google.protobuf.EnumOptions */
 
 extern const upb_msglayout google_protobuf_EnumOptions_msginit;
 UPB_INLINE google_protobuf_EnumOptions *google_protobuf_EnumOptions_new(upb_arena *arena) {
@@ -586,13 +583,16 @@ UPB_INLINE char *google_protobuf_EnumOptions_serialize(const google_protobuf_Enu
   return upb_encode(msg, &google_protobuf_EnumOptions_msginit, arena, len);
 }
 
-struct google_protobuf_EnumValueOptions {
-  struct {
-    bool deprecated:1;
-  } has;
-  bool deprecated;
-  upb_array* uninterpreted_option;
-};
+UPB_INLINE bool google_protobuf_EnumOptions_allow_alias(const google_protobuf_EnumOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(1, 1)); }
+UPB_INLINE bool google_protobuf_EnumOptions_deprecated(const google_protobuf_EnumOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(2, 2)); }
+UPB_INLINE const upb_array* google_protobuf_EnumOptions_uninterpreted_option(const google_protobuf_EnumOptions *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(4, 8)); }
+
+UPB_INLINE void google_protobuf_EnumOptions_set_allow_alias(google_protobuf_EnumOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(1, 1)) = value; }
+UPB_INLINE void google_protobuf_EnumOptions_set_deprecated(google_protobuf_EnumOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(2, 2)) = value; }
+UPB_INLINE void google_protobuf_EnumOptions_set_uninterpreted_option(google_protobuf_EnumOptions *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(4, 8)) = value; }
+
+
+/* google.protobuf.EnumValueOptions */
 
 extern const upb_msglayout google_protobuf_EnumValueOptions_msginit;
 UPB_INLINE google_protobuf_EnumValueOptions *google_protobuf_EnumValueOptions_new(upb_arena *arena) {
@@ -606,13 +606,14 @@ UPB_INLINE char *google_protobuf_EnumValueOptions_serialize(const google_protobu
   return upb_encode(msg, &google_protobuf_EnumValueOptions_msginit, arena, len);
 }
 
-struct google_protobuf_ServiceOptions {
-  struct {
-    bool deprecated:1;
-  } has;
-  bool deprecated;
-  upb_array* uninterpreted_option;
-};
+UPB_INLINE bool google_protobuf_EnumValueOptions_deprecated(const google_protobuf_EnumValueOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(1, 1)); }
+UPB_INLINE const upb_array* google_protobuf_EnumValueOptions_uninterpreted_option(const google_protobuf_EnumValueOptions *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(4, 8)); }
+
+UPB_INLINE void google_protobuf_EnumValueOptions_set_deprecated(google_protobuf_EnumValueOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(1, 1)) = value; }
+UPB_INLINE void google_protobuf_EnumValueOptions_set_uninterpreted_option(google_protobuf_EnumValueOptions *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(4, 8)) = value; }
+
+
+/* google.protobuf.ServiceOptions */
 
 extern const upb_msglayout google_protobuf_ServiceOptions_msginit;
 UPB_INLINE google_protobuf_ServiceOptions *google_protobuf_ServiceOptions_new(upb_arena *arena) {
@@ -626,15 +627,14 @@ UPB_INLINE char *google_protobuf_ServiceOptions_serialize(const google_protobuf_
   return upb_encode(msg, &google_protobuf_ServiceOptions_msginit, arena, len);
 }
 
-struct google_protobuf_MethodOptions {
-  struct {
-    bool idempotency_level:1;
-    bool deprecated:1;
-  } has;
-  google_protobuf_MethodOptions_IdempotencyLevel idempotency_level;
-  bool deprecated;
-  upb_array* uninterpreted_option;
-};
+UPB_INLINE bool google_protobuf_ServiceOptions_deprecated(const google_protobuf_ServiceOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(1, 1)); }
+UPB_INLINE const upb_array* google_protobuf_ServiceOptions_uninterpreted_option(const google_protobuf_ServiceOptions *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(4, 8)); }
+
+UPB_INLINE void google_protobuf_ServiceOptions_set_deprecated(google_protobuf_ServiceOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(1, 1)) = value; }
+UPB_INLINE void google_protobuf_ServiceOptions_set_uninterpreted_option(google_protobuf_ServiceOptions *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(4, 8)) = value; }
+
+
+/* google.protobuf.MethodOptions */
 
 extern const upb_msglayout google_protobuf_MethodOptions_msginit;
 UPB_INLINE google_protobuf_MethodOptions *google_protobuf_MethodOptions_new(upb_arena *arena) {
@@ -648,23 +648,16 @@ UPB_INLINE char *google_protobuf_MethodOptions_serialize(const google_protobuf_M
   return upb_encode(msg, &google_protobuf_MethodOptions_msginit, arena, len);
 }
 
-struct google_protobuf_UninterpretedOption {
-  struct {
-    bool positive_int_value:1;
-    bool negative_int_value:1;
-    bool double_value:1;
-    bool identifier_value:1;
-    bool string_value:1;
-    bool aggregate_value:1;
-  } has;
-  uint64_t positive_int_value;
-  int64_t negative_int_value;
-  double double_value;
-  upb_stringview identifier_value;
-  upb_stringview string_value;
-  upb_stringview aggregate_value;
-  upb_array* name;
-};
+UPB_INLINE bool google_protobuf_MethodOptions_deprecated(const google_protobuf_MethodOptions *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(16, 16)); }
+UPB_INLINE google_protobuf_MethodOptions_IdempotencyLevel google_protobuf_MethodOptions_idempotency_level(const google_protobuf_MethodOptions *msg) { return UPB_FIELD_AT(msg, google_protobuf_MethodOptions_IdempotencyLevel, UPB_SIZE(8, 8)); }
+UPB_INLINE const upb_array* google_protobuf_MethodOptions_uninterpreted_option(const google_protobuf_MethodOptions *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(20, 24)); }
+
+UPB_INLINE void google_protobuf_MethodOptions_set_deprecated(google_protobuf_MethodOptions *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(16, 16)) = value; }
+UPB_INLINE void google_protobuf_MethodOptions_set_idempotency_level(google_protobuf_MethodOptions *msg, google_protobuf_MethodOptions_IdempotencyLevel value) { UPB_FIELD_AT(msg, google_protobuf_MethodOptions_IdempotencyLevel, UPB_SIZE(8, 8)) = value; }
+UPB_INLINE void google_protobuf_MethodOptions_set_uninterpreted_option(google_protobuf_MethodOptions *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(20, 24)) = value; }
+
+
+/* google.protobuf.UninterpretedOption */
 
 extern const upb_msglayout google_protobuf_UninterpretedOption_msginit;
 UPB_INLINE google_protobuf_UninterpretedOption *google_protobuf_UninterpretedOption_new(upb_arena *arena) {
@@ -678,14 +671,24 @@ UPB_INLINE char *google_protobuf_UninterpretedOption_serialize(const google_prot
   return upb_encode(msg, &google_protobuf_UninterpretedOption_msginit, arena, len);
 }
 
-struct google_protobuf_UninterpretedOption_NamePart {
-  struct {
-    bool is_extension:1;
-    bool name_part:1;
-  } has;
-  bool is_extension;
-  upb_stringview name_part;
-};
+UPB_INLINE const upb_array* google_protobuf_UninterpretedOption_name(const google_protobuf_UninterpretedOption *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(56, 80)); }
+UPB_INLINE upb_stringview google_protobuf_UninterpretedOption_identifier_value(const google_protobuf_UninterpretedOption *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(32, 32)); }
+UPB_INLINE uint64_t google_protobuf_UninterpretedOption_positive_int_value(const google_protobuf_UninterpretedOption *msg) { return UPB_FIELD_AT(msg, uint64_t, UPB_SIZE(8, 8)); }
+UPB_INLINE int64_t google_protobuf_UninterpretedOption_negative_int_value(const google_protobuf_UninterpretedOption *msg) { return UPB_FIELD_AT(msg, int64_t, UPB_SIZE(16, 16)); }
+UPB_INLINE double google_protobuf_UninterpretedOption_double_value(const google_protobuf_UninterpretedOption *msg) { return UPB_FIELD_AT(msg, double, UPB_SIZE(24, 24)); }
+UPB_INLINE upb_stringview google_protobuf_UninterpretedOption_string_value(const google_protobuf_UninterpretedOption *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(40, 48)); }
+UPB_INLINE upb_stringview google_protobuf_UninterpretedOption_aggregate_value(const google_protobuf_UninterpretedOption *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(48, 64)); }
+
+UPB_INLINE void google_protobuf_UninterpretedOption_set_name(google_protobuf_UninterpretedOption *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(56, 80)) = value; }
+UPB_INLINE void google_protobuf_UninterpretedOption_set_identifier_value(google_protobuf_UninterpretedOption *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(32, 32)) = value; }
+UPB_INLINE void google_protobuf_UninterpretedOption_set_positive_int_value(google_protobuf_UninterpretedOption *msg, uint64_t value) { UPB_FIELD_AT(msg, uint64_t, UPB_SIZE(8, 8)) = value; }
+UPB_INLINE void google_protobuf_UninterpretedOption_set_negative_int_value(google_protobuf_UninterpretedOption *msg, int64_t value) { UPB_FIELD_AT(msg, int64_t, UPB_SIZE(16, 16)) = value; }
+UPB_INLINE void google_protobuf_UninterpretedOption_set_double_value(google_protobuf_UninterpretedOption *msg, double value) { UPB_FIELD_AT(msg, double, UPB_SIZE(24, 24)) = value; }
+UPB_INLINE void google_protobuf_UninterpretedOption_set_string_value(google_protobuf_UninterpretedOption *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(40, 48)) = value; }
+UPB_INLINE void google_protobuf_UninterpretedOption_set_aggregate_value(google_protobuf_UninterpretedOption *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(48, 64)) = value; }
+
+
+/* google.protobuf.UninterpretedOption.NamePart */
 
 extern const upb_msglayout google_protobuf_UninterpretedOption_NamePart_msginit;
 UPB_INLINE google_protobuf_UninterpretedOption_NamePart *google_protobuf_UninterpretedOption_NamePart_new(upb_arena *arena) {
@@ -699,9 +702,14 @@ UPB_INLINE char *google_protobuf_UninterpretedOption_NamePart_serialize(const go
   return upb_encode(msg, &google_protobuf_UninterpretedOption_NamePart_msginit, arena, len);
 }
 
-struct google_protobuf_SourceCodeInfo {
-  upb_array* location;
-};
+UPB_INLINE upb_stringview google_protobuf_UninterpretedOption_NamePart_name_part(const google_protobuf_UninterpretedOption_NamePart *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)); }
+UPB_INLINE bool google_protobuf_UninterpretedOption_NamePart_is_extension(const google_protobuf_UninterpretedOption_NamePart *msg) { return UPB_FIELD_AT(msg, bool, UPB_SIZE(1, 1)); }
+
+UPB_INLINE void google_protobuf_UninterpretedOption_NamePart_set_name_part(google_protobuf_UninterpretedOption_NamePart *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)) = value; }
+UPB_INLINE void google_protobuf_UninterpretedOption_NamePart_set_is_extension(google_protobuf_UninterpretedOption_NamePart *msg, bool value) { UPB_FIELD_AT(msg, bool, UPB_SIZE(1, 1)) = value; }
+
+
+/* google.protobuf.SourceCodeInfo */
 
 extern const upb_msglayout google_protobuf_SourceCodeInfo_msginit;
 UPB_INLINE google_protobuf_SourceCodeInfo *google_protobuf_SourceCodeInfo_new(upb_arena *arena) {
@@ -715,17 +723,12 @@ UPB_INLINE char *google_protobuf_SourceCodeInfo_serialize(const google_protobuf_
   return upb_encode(msg, &google_protobuf_SourceCodeInfo_msginit, arena, len);
 }
 
-struct google_protobuf_SourceCodeInfo_Location {
-  struct {
-    bool leading_comments:1;
-    bool trailing_comments:1;
-  } has;
-  upb_stringview leading_comments;
-  upb_stringview trailing_comments;
-  upb_array* path;
-  upb_array* span;
-  upb_array* leading_detached_comments;
-};
+UPB_INLINE const upb_array* google_protobuf_SourceCodeInfo_location(const google_protobuf_SourceCodeInfo *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(0, 0)); }
+
+UPB_INLINE void google_protobuf_SourceCodeInfo_set_location(google_protobuf_SourceCodeInfo *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(0, 0)) = value; }
+
+
+/* google.protobuf.SourceCodeInfo.Location */
 
 extern const upb_msglayout google_protobuf_SourceCodeInfo_Location_msginit;
 UPB_INLINE google_protobuf_SourceCodeInfo_Location *google_protobuf_SourceCodeInfo_Location_new(upb_arena *arena) {
@@ -739,9 +742,20 @@ UPB_INLINE char *google_protobuf_SourceCodeInfo_Location_serialize(const google_
   return upb_encode(msg, &google_protobuf_SourceCodeInfo_Location_msginit, arena, len);
 }
 
-struct google_protobuf_GeneratedCodeInfo {
-  upb_array* annotation;
-};
+UPB_INLINE const upb_array* google_protobuf_SourceCodeInfo_Location_path(const google_protobuf_SourceCodeInfo_Location *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(24, 48)); }
+UPB_INLINE const upb_array* google_protobuf_SourceCodeInfo_Location_span(const google_protobuf_SourceCodeInfo_Location *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(28, 56)); }
+UPB_INLINE upb_stringview google_protobuf_SourceCodeInfo_Location_leading_comments(const google_protobuf_SourceCodeInfo_Location *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)); }
+UPB_INLINE upb_stringview google_protobuf_SourceCodeInfo_Location_trailing_comments(const google_protobuf_SourceCodeInfo_Location *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(16, 32)); }
+UPB_INLINE const upb_array* google_protobuf_SourceCodeInfo_Location_leading_detached_comments(const google_protobuf_SourceCodeInfo_Location *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(32, 64)); }
+
+UPB_INLINE void google_protobuf_SourceCodeInfo_Location_set_path(google_protobuf_SourceCodeInfo_Location *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(24, 48)) = value; }
+UPB_INLINE void google_protobuf_SourceCodeInfo_Location_set_span(google_protobuf_SourceCodeInfo_Location *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(28, 56)) = value; }
+UPB_INLINE void google_protobuf_SourceCodeInfo_Location_set_leading_comments(google_protobuf_SourceCodeInfo_Location *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(8, 16)) = value; }
+UPB_INLINE void google_protobuf_SourceCodeInfo_Location_set_trailing_comments(google_protobuf_SourceCodeInfo_Location *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(16, 32)) = value; }
+UPB_INLINE void google_protobuf_SourceCodeInfo_Location_set_leading_detached_comments(google_protobuf_SourceCodeInfo_Location *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(32, 64)) = value; }
+
+
+/* google.protobuf.GeneratedCodeInfo */
 
 extern const upb_msglayout google_protobuf_GeneratedCodeInfo_msginit;
 UPB_INLINE google_protobuf_GeneratedCodeInfo *google_protobuf_GeneratedCodeInfo_new(upb_arena *arena) {
@@ -755,17 +769,12 @@ UPB_INLINE char *google_protobuf_GeneratedCodeInfo_serialize(const google_protob
   return upb_encode(msg, &google_protobuf_GeneratedCodeInfo_msginit, arena, len);
 }
 
-struct google_protobuf_GeneratedCodeInfo_Annotation {
-  struct {
-    bool begin:1;
-    bool end:1;
-    bool source_file:1;
-  } has;
-  int32_t begin;
-  int32_t end;
-  upb_stringview source_file;
-  upb_array* path;
-};
+UPB_INLINE const upb_array* google_protobuf_GeneratedCodeInfo_annotation(const google_protobuf_GeneratedCodeInfo *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(0, 0)); }
+
+UPB_INLINE void google_protobuf_GeneratedCodeInfo_set_annotation(google_protobuf_GeneratedCodeInfo *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(0, 0)) = value; }
+
+
+/* google.protobuf.GeneratedCodeInfo.Annotation */
 
 extern const upb_msglayout google_protobuf_GeneratedCodeInfo_Annotation_msginit;
 UPB_INLINE google_protobuf_GeneratedCodeInfo_Annotation *google_protobuf_GeneratedCodeInfo_Annotation_new(upb_arena *arena) {
@@ -779,6 +788,18 @@ UPB_INLINE char *google_protobuf_GeneratedCodeInfo_Annotation_serialize(const go
   return upb_encode(msg, &google_protobuf_GeneratedCodeInfo_Annotation_msginit, arena, len);
 }
 
+UPB_INLINE const upb_array* google_protobuf_GeneratedCodeInfo_Annotation_path(const google_protobuf_GeneratedCodeInfo_Annotation *msg) { return UPB_FIELD_AT(msg, const upb_array*, UPB_SIZE(24, 32)); }
+UPB_INLINE upb_stringview google_protobuf_GeneratedCodeInfo_Annotation_source_file(const google_protobuf_GeneratedCodeInfo_Annotation *msg) { return UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(16, 16)); }
+UPB_INLINE int32_t google_protobuf_GeneratedCodeInfo_Annotation_begin(const google_protobuf_GeneratedCodeInfo_Annotation *msg) { return UPB_FIELD_AT(msg, int32_t, UPB_SIZE(4, 4)); }
+UPB_INLINE int32_t google_protobuf_GeneratedCodeInfo_Annotation_end(const google_protobuf_GeneratedCodeInfo_Annotation *msg) { return UPB_FIELD_AT(msg, int32_t, UPB_SIZE(8, 8)); }
+
+UPB_INLINE void google_protobuf_GeneratedCodeInfo_Annotation_set_path(google_protobuf_GeneratedCodeInfo_Annotation *msg, upb_array* value) { UPB_FIELD_AT(msg, upb_array*, UPB_SIZE(24, 32)) = value; }
+UPB_INLINE void google_protobuf_GeneratedCodeInfo_Annotation_set_source_file(google_protobuf_GeneratedCodeInfo_Annotation *msg, upb_stringview value) { UPB_FIELD_AT(msg, upb_stringview, UPB_SIZE(16, 16)) = value; }
+UPB_INLINE void google_protobuf_GeneratedCodeInfo_Annotation_set_begin(google_protobuf_GeneratedCodeInfo_Annotation *msg, int32_t value) { UPB_FIELD_AT(msg, int32_t, UPB_SIZE(4, 4)) = value; }
+UPB_INLINE void google_protobuf_GeneratedCodeInfo_Annotation_set_end(google_protobuf_GeneratedCodeInfo_Annotation *msg, int32_t value) { UPB_FIELD_AT(msg, int32_t, UPB_SIZE(8, 8)) = value; }
+
+
 UPB_END_EXTERN_C
+#include "upb/port_undef.inc"
 
 #endif  /* GOOGLE_PROTOBUF_DESCRIPTOR_PROTO_UPB_H_ */

--- a/google/protobuf/descriptor.upb.h
+++ b/google/protobuf/descriptor.upb.h
@@ -11,6 +11,8 @@
 
 #include "upb/msg.h"
 
+#include "upb/decode.h"
+#include "upb/encode.h"
 UPB_BEGIN_EXTERN_C
 
 struct google_protobuf_FileDescriptorSet;
@@ -120,573 +122,662 @@ typedef enum {
   google_protobuf_MethodOptions_IDEMPOTENT = 2
 } google_protobuf_MethodOptions_IdempotencyLevel;
 
-/* google_protobuf_FileDescriptorSet */
+struct google_protobuf_FileDescriptorSet {
+  upb_array* file;
+};
+
 extern const upb_msglayout google_protobuf_FileDescriptorSet_msginit;
-google_protobuf_FileDescriptorSet *google_protobuf_FileDescriptorSet_new(upb_env *env);
-google_protobuf_FileDescriptorSet *google_protobuf_FileDescriptorSet_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_FileDescriptorSet_serialize(google_protobuf_FileDescriptorSet *msg, upb_env *env, size_t *len);
-void google_protobuf_FileDescriptorSet_free(google_protobuf_FileDescriptorSet *msg, upb_env *env);
+UPB_INLINE google_protobuf_FileDescriptorSet *google_protobuf_FileDescriptorSet_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_FileDescriptorSet_msginit, arena);
+}
+UPB_INLINE google_protobuf_FileDescriptorSet *google_protobuf_FileDescriptorSet_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_FileDescriptorSet *ret = google_protobuf_FileDescriptorSet_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_FileDescriptorSet_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_FileDescriptorSet_serialize(const google_protobuf_FileDescriptorSet *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_FileDescriptorSet_msginit, arena, len);
+}
 
-/* getters. */
-const upb_array* google_protobuf_FileDescriptorSet_file(const google_protobuf_FileDescriptorSet *msg);
+struct google_protobuf_FileDescriptorProto {
+  struct {
+    bool name:1;
+    bool package:1;
+    bool syntax:1;
+    bool options:1;
+    bool source_code_info:1;
+  } has;
+  upb_stringview name;
+  upb_stringview package;
+  upb_stringview syntax;
+  google_protobuf_FileOptions* options;
+  google_protobuf_SourceCodeInfo* source_code_info;
+  upb_array* dependency;
+  upb_array* message_type;
+  upb_array* enum_type;
+  upb_array* service;
+  upb_array* extension;
+  upb_array* public_dependency;
+  upb_array* weak_dependency;
+};
 
-/* setters. */
-void google_protobuf_FileDescriptorSet_set_file(google_protobuf_FileDescriptorSet *msg, upb_array* value);
-
-
-/* google_protobuf_FileDescriptorProto */
 extern const upb_msglayout google_protobuf_FileDescriptorProto_msginit;
-google_protobuf_FileDescriptorProto *google_protobuf_FileDescriptorProto_new(upb_env *env);
-google_protobuf_FileDescriptorProto *google_protobuf_FileDescriptorProto_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_FileDescriptorProto_serialize(google_protobuf_FileDescriptorProto *msg, upb_env *env, size_t *len);
-void google_protobuf_FileDescriptorProto_free(google_protobuf_FileDescriptorProto *msg, upb_env *env);
+UPB_INLINE google_protobuf_FileDescriptorProto *google_protobuf_FileDescriptorProto_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_FileDescriptorProto_msginit, arena);
+}
+UPB_INLINE google_protobuf_FileDescriptorProto *google_protobuf_FileDescriptorProto_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_FileDescriptorProto *ret = google_protobuf_FileDescriptorProto_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_FileDescriptorProto_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_FileDescriptorProto_serialize(const google_protobuf_FileDescriptorProto *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_FileDescriptorProto_msginit, arena, len);
+}
 
-/* getters. */
-upb_stringview google_protobuf_FileDescriptorProto_name(const google_protobuf_FileDescriptorProto *msg);
-upb_stringview google_protobuf_FileDescriptorProto_package(const google_protobuf_FileDescriptorProto *msg);
-const upb_array* google_protobuf_FileDescriptorProto_dependency(const google_protobuf_FileDescriptorProto *msg);
-const upb_array* google_protobuf_FileDescriptorProto_message_type(const google_protobuf_FileDescriptorProto *msg);
-const upb_array* google_protobuf_FileDescriptorProto_enum_type(const google_protobuf_FileDescriptorProto *msg);
-const upb_array* google_protobuf_FileDescriptorProto_service(const google_protobuf_FileDescriptorProto *msg);
-const upb_array* google_protobuf_FileDescriptorProto_extension(const google_protobuf_FileDescriptorProto *msg);
-const google_protobuf_FileOptions* google_protobuf_FileDescriptorProto_options(const google_protobuf_FileDescriptorProto *msg);
-const google_protobuf_SourceCodeInfo* google_protobuf_FileDescriptorProto_source_code_info(const google_protobuf_FileDescriptorProto *msg);
-const upb_array* google_protobuf_FileDescriptorProto_public_dependency(const google_protobuf_FileDescriptorProto *msg);
-const upb_array* google_protobuf_FileDescriptorProto_weak_dependency(const google_protobuf_FileDescriptorProto *msg);
-upb_stringview google_protobuf_FileDescriptorProto_syntax(const google_protobuf_FileDescriptorProto *msg);
+struct google_protobuf_DescriptorProto {
+  struct {
+    bool name:1;
+    bool options:1;
+  } has;
+  upb_stringview name;
+  google_protobuf_MessageOptions* options;
+  upb_array* field;
+  upb_array* nested_type;
+  upb_array* enum_type;
+  upb_array* extension_range;
+  upb_array* extension;
+  upb_array* oneof_decl;
+  upb_array* reserved_range;
+  upb_array* reserved_name;
+};
 
-/* setters. */
-void google_protobuf_FileDescriptorProto_set_name(google_protobuf_FileDescriptorProto *msg, upb_stringview value);
-void google_protobuf_FileDescriptorProto_set_package(google_protobuf_FileDescriptorProto *msg, upb_stringview value);
-void google_protobuf_FileDescriptorProto_set_dependency(google_protobuf_FileDescriptorProto *msg, upb_array* value);
-void google_protobuf_FileDescriptorProto_set_message_type(google_protobuf_FileDescriptorProto *msg, upb_array* value);
-void google_protobuf_FileDescriptorProto_set_enum_type(google_protobuf_FileDescriptorProto *msg, upb_array* value);
-void google_protobuf_FileDescriptorProto_set_service(google_protobuf_FileDescriptorProto *msg, upb_array* value);
-void google_protobuf_FileDescriptorProto_set_extension(google_protobuf_FileDescriptorProto *msg, upb_array* value);
-void google_protobuf_FileDescriptorProto_set_options(google_protobuf_FileDescriptorProto *msg, google_protobuf_FileOptions* value);
-void google_protobuf_FileDescriptorProto_set_source_code_info(google_protobuf_FileDescriptorProto *msg, google_protobuf_SourceCodeInfo* value);
-void google_protobuf_FileDescriptorProto_set_public_dependency(google_protobuf_FileDescriptorProto *msg, upb_array* value);
-void google_protobuf_FileDescriptorProto_set_weak_dependency(google_protobuf_FileDescriptorProto *msg, upb_array* value);
-void google_protobuf_FileDescriptorProto_set_syntax(google_protobuf_FileDescriptorProto *msg, upb_stringview value);
-
-
-/* google_protobuf_DescriptorProto */
 extern const upb_msglayout google_protobuf_DescriptorProto_msginit;
-google_protobuf_DescriptorProto *google_protobuf_DescriptorProto_new(upb_env *env);
-google_protobuf_DescriptorProto *google_protobuf_DescriptorProto_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_DescriptorProto_serialize(google_protobuf_DescriptorProto *msg, upb_env *env, size_t *len);
-void google_protobuf_DescriptorProto_free(google_protobuf_DescriptorProto *msg, upb_env *env);
+UPB_INLINE google_protobuf_DescriptorProto *google_protobuf_DescriptorProto_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_DescriptorProto_msginit, arena);
+}
+UPB_INLINE google_protobuf_DescriptorProto *google_protobuf_DescriptorProto_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_DescriptorProto *ret = google_protobuf_DescriptorProto_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_DescriptorProto_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_DescriptorProto_serialize(const google_protobuf_DescriptorProto *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_DescriptorProto_msginit, arena, len);
+}
 
-/* getters. */
-upb_stringview google_protobuf_DescriptorProto_name(const google_protobuf_DescriptorProto *msg);
-const upb_array* google_protobuf_DescriptorProto_field(const google_protobuf_DescriptorProto *msg);
-const upb_array* google_protobuf_DescriptorProto_nested_type(const google_protobuf_DescriptorProto *msg);
-const upb_array* google_protobuf_DescriptorProto_enum_type(const google_protobuf_DescriptorProto *msg);
-const upb_array* google_protobuf_DescriptorProto_extension_range(const google_protobuf_DescriptorProto *msg);
-const upb_array* google_protobuf_DescriptorProto_extension(const google_protobuf_DescriptorProto *msg);
-const google_protobuf_MessageOptions* google_protobuf_DescriptorProto_options(const google_protobuf_DescriptorProto *msg);
-const upb_array* google_protobuf_DescriptorProto_oneof_decl(const google_protobuf_DescriptorProto *msg);
-const upb_array* google_protobuf_DescriptorProto_reserved_range(const google_protobuf_DescriptorProto *msg);
-const upb_array* google_protobuf_DescriptorProto_reserved_name(const google_protobuf_DescriptorProto *msg);
+struct google_protobuf_DescriptorProto_ExtensionRange {
+  struct {
+    bool start:1;
+    bool end:1;
+    bool options:1;
+  } has;
+  int32_t start;
+  int32_t end;
+  google_protobuf_ExtensionRangeOptions* options;
+};
 
-/* setters. */
-void google_protobuf_DescriptorProto_set_name(google_protobuf_DescriptorProto *msg, upb_stringview value);
-void google_protobuf_DescriptorProto_set_field(google_protobuf_DescriptorProto *msg, upb_array* value);
-void google_protobuf_DescriptorProto_set_nested_type(google_protobuf_DescriptorProto *msg, upb_array* value);
-void google_protobuf_DescriptorProto_set_enum_type(google_protobuf_DescriptorProto *msg, upb_array* value);
-void google_protobuf_DescriptorProto_set_extension_range(google_protobuf_DescriptorProto *msg, upb_array* value);
-void google_protobuf_DescriptorProto_set_extension(google_protobuf_DescriptorProto *msg, upb_array* value);
-void google_protobuf_DescriptorProto_set_options(google_protobuf_DescriptorProto *msg, google_protobuf_MessageOptions* value);
-void google_protobuf_DescriptorProto_set_oneof_decl(google_protobuf_DescriptorProto *msg, upb_array* value);
-void google_protobuf_DescriptorProto_set_reserved_range(google_protobuf_DescriptorProto *msg, upb_array* value);
-void google_protobuf_DescriptorProto_set_reserved_name(google_protobuf_DescriptorProto *msg, upb_array* value);
-
-
-/* google_protobuf_DescriptorProto_ExtensionRange */
 extern const upb_msglayout google_protobuf_DescriptorProto_ExtensionRange_msginit;
-google_protobuf_DescriptorProto_ExtensionRange *google_protobuf_DescriptorProto_ExtensionRange_new(upb_env *env);
-google_protobuf_DescriptorProto_ExtensionRange *google_protobuf_DescriptorProto_ExtensionRange_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_DescriptorProto_ExtensionRange_serialize(google_protobuf_DescriptorProto_ExtensionRange *msg, upb_env *env, size_t *len);
-void google_protobuf_DescriptorProto_ExtensionRange_free(google_protobuf_DescriptorProto_ExtensionRange *msg, upb_env *env);
+UPB_INLINE google_protobuf_DescriptorProto_ExtensionRange *google_protobuf_DescriptorProto_ExtensionRange_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_DescriptorProto_ExtensionRange_msginit, arena);
+}
+UPB_INLINE google_protobuf_DescriptorProto_ExtensionRange *google_protobuf_DescriptorProto_ExtensionRange_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_DescriptorProto_ExtensionRange *ret = google_protobuf_DescriptorProto_ExtensionRange_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_DescriptorProto_ExtensionRange_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_DescriptorProto_ExtensionRange_serialize(const google_protobuf_DescriptorProto_ExtensionRange *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_DescriptorProto_ExtensionRange_msginit, arena, len);
+}
 
-/* getters. */
-int32_t google_protobuf_DescriptorProto_ExtensionRange_start(const google_protobuf_DescriptorProto_ExtensionRange *msg);
-int32_t google_protobuf_DescriptorProto_ExtensionRange_end(const google_protobuf_DescriptorProto_ExtensionRange *msg);
-const google_protobuf_ExtensionRangeOptions* google_protobuf_DescriptorProto_ExtensionRange_options(const google_protobuf_DescriptorProto_ExtensionRange *msg);
+struct google_protobuf_DescriptorProto_ReservedRange {
+  struct {
+    bool start:1;
+    bool end:1;
+  } has;
+  int32_t start;
+  int32_t end;
+};
 
-/* setters. */
-void google_protobuf_DescriptorProto_ExtensionRange_set_start(google_protobuf_DescriptorProto_ExtensionRange *msg, int32_t value);
-void google_protobuf_DescriptorProto_ExtensionRange_set_end(google_protobuf_DescriptorProto_ExtensionRange *msg, int32_t value);
-void google_protobuf_DescriptorProto_ExtensionRange_set_options(google_protobuf_DescriptorProto_ExtensionRange *msg, google_protobuf_ExtensionRangeOptions* value);
-
-
-/* google_protobuf_DescriptorProto_ReservedRange */
 extern const upb_msglayout google_protobuf_DescriptorProto_ReservedRange_msginit;
-google_protobuf_DescriptorProto_ReservedRange *google_protobuf_DescriptorProto_ReservedRange_new(upb_env *env);
-google_protobuf_DescriptorProto_ReservedRange *google_protobuf_DescriptorProto_ReservedRange_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_DescriptorProto_ReservedRange_serialize(google_protobuf_DescriptorProto_ReservedRange *msg, upb_env *env, size_t *len);
-void google_protobuf_DescriptorProto_ReservedRange_free(google_protobuf_DescriptorProto_ReservedRange *msg, upb_env *env);
+UPB_INLINE google_protobuf_DescriptorProto_ReservedRange *google_protobuf_DescriptorProto_ReservedRange_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_DescriptorProto_ReservedRange_msginit, arena);
+}
+UPB_INLINE google_protobuf_DescriptorProto_ReservedRange *google_protobuf_DescriptorProto_ReservedRange_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_DescriptorProto_ReservedRange *ret = google_protobuf_DescriptorProto_ReservedRange_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_DescriptorProto_ReservedRange_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_DescriptorProto_ReservedRange_serialize(const google_protobuf_DescriptorProto_ReservedRange *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_DescriptorProto_ReservedRange_msginit, arena, len);
+}
 
-/* getters. */
-int32_t google_protobuf_DescriptorProto_ReservedRange_start(const google_protobuf_DescriptorProto_ReservedRange *msg);
-int32_t google_protobuf_DescriptorProto_ReservedRange_end(const google_protobuf_DescriptorProto_ReservedRange *msg);
+struct google_protobuf_ExtensionRangeOptions {
+  upb_array* uninterpreted_option;
+};
 
-/* setters. */
-void google_protobuf_DescriptorProto_ReservedRange_set_start(google_protobuf_DescriptorProto_ReservedRange *msg, int32_t value);
-void google_protobuf_DescriptorProto_ReservedRange_set_end(google_protobuf_DescriptorProto_ReservedRange *msg, int32_t value);
-
-
-/* google_protobuf_ExtensionRangeOptions */
 extern const upb_msglayout google_protobuf_ExtensionRangeOptions_msginit;
-google_protobuf_ExtensionRangeOptions *google_protobuf_ExtensionRangeOptions_new(upb_env *env);
-google_protobuf_ExtensionRangeOptions *google_protobuf_ExtensionRangeOptions_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_ExtensionRangeOptions_serialize(google_protobuf_ExtensionRangeOptions *msg, upb_env *env, size_t *len);
-void google_protobuf_ExtensionRangeOptions_free(google_protobuf_ExtensionRangeOptions *msg, upb_env *env);
+UPB_INLINE google_protobuf_ExtensionRangeOptions *google_protobuf_ExtensionRangeOptions_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_ExtensionRangeOptions_msginit, arena);
+}
+UPB_INLINE google_protobuf_ExtensionRangeOptions *google_protobuf_ExtensionRangeOptions_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_ExtensionRangeOptions *ret = google_protobuf_ExtensionRangeOptions_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_ExtensionRangeOptions_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_ExtensionRangeOptions_serialize(const google_protobuf_ExtensionRangeOptions *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_ExtensionRangeOptions_msginit, arena, len);
+}
 
-/* getters. */
-const upb_array* google_protobuf_ExtensionRangeOptions_uninterpreted_option(const google_protobuf_ExtensionRangeOptions *msg);
+struct google_protobuf_FieldDescriptorProto {
+  struct {
+    bool label:1;
+    bool type:1;
+    bool number:1;
+    bool oneof_index:1;
+    bool name:1;
+    bool extendee:1;
+    bool type_name:1;
+    bool default_value:1;
+    bool json_name:1;
+    bool options:1;
+  } has;
+  google_protobuf_FieldDescriptorProto_Label label;
+  google_protobuf_FieldDescriptorProto_Type type;
+  int32_t number;
+  int32_t oneof_index;
+  upb_stringview name;
+  upb_stringview extendee;
+  upb_stringview type_name;
+  upb_stringview default_value;
+  upb_stringview json_name;
+  google_protobuf_FieldOptions* options;
+};
 
-/* setters. */
-void google_protobuf_ExtensionRangeOptions_set_uninterpreted_option(google_protobuf_ExtensionRangeOptions *msg, upb_array* value);
-
-
-/* google_protobuf_FieldDescriptorProto */
 extern const upb_msglayout google_protobuf_FieldDescriptorProto_msginit;
-google_protobuf_FieldDescriptorProto *google_protobuf_FieldDescriptorProto_new(upb_env *env);
-google_protobuf_FieldDescriptorProto *google_protobuf_FieldDescriptorProto_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_FieldDescriptorProto_serialize(google_protobuf_FieldDescriptorProto *msg, upb_env *env, size_t *len);
-void google_protobuf_FieldDescriptorProto_free(google_protobuf_FieldDescriptorProto *msg, upb_env *env);
+UPB_INLINE google_protobuf_FieldDescriptorProto *google_protobuf_FieldDescriptorProto_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_FieldDescriptorProto_msginit, arena);
+}
+UPB_INLINE google_protobuf_FieldDescriptorProto *google_protobuf_FieldDescriptorProto_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_FieldDescriptorProto *ret = google_protobuf_FieldDescriptorProto_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_FieldDescriptorProto_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_FieldDescriptorProto_serialize(const google_protobuf_FieldDescriptorProto *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_FieldDescriptorProto_msginit, arena, len);
+}
 
-/* getters. */
-upb_stringview google_protobuf_FieldDescriptorProto_name(const google_protobuf_FieldDescriptorProto *msg);
-upb_stringview google_protobuf_FieldDescriptorProto_extendee(const google_protobuf_FieldDescriptorProto *msg);
-int32_t google_protobuf_FieldDescriptorProto_number(const google_protobuf_FieldDescriptorProto *msg);
-google_protobuf_FieldDescriptorProto_Label google_protobuf_FieldDescriptorProto_label(const google_protobuf_FieldDescriptorProto *msg);
-google_protobuf_FieldDescriptorProto_Type google_protobuf_FieldDescriptorProto_type(const google_protobuf_FieldDescriptorProto *msg);
-upb_stringview google_protobuf_FieldDescriptorProto_type_name(const google_protobuf_FieldDescriptorProto *msg);
-upb_stringview google_protobuf_FieldDescriptorProto_default_value(const google_protobuf_FieldDescriptorProto *msg);
-const google_protobuf_FieldOptions* google_protobuf_FieldDescriptorProto_options(const google_protobuf_FieldDescriptorProto *msg);
-int32_t google_protobuf_FieldDescriptorProto_oneof_index(const google_protobuf_FieldDescriptorProto *msg);
-upb_stringview google_protobuf_FieldDescriptorProto_json_name(const google_protobuf_FieldDescriptorProto *msg);
+struct google_protobuf_OneofDescriptorProto {
+  struct {
+    bool name:1;
+    bool options:1;
+  } has;
+  upb_stringview name;
+  google_protobuf_OneofOptions* options;
+};
 
-/* setters. */
-void google_protobuf_FieldDescriptorProto_set_name(google_protobuf_FieldDescriptorProto *msg, upb_stringview value);
-void google_protobuf_FieldDescriptorProto_set_extendee(google_protobuf_FieldDescriptorProto *msg, upb_stringview value);
-void google_protobuf_FieldDescriptorProto_set_number(google_protobuf_FieldDescriptorProto *msg, int32_t value);
-void google_protobuf_FieldDescriptorProto_set_label(google_protobuf_FieldDescriptorProto *msg, google_protobuf_FieldDescriptorProto_Label value);
-void google_protobuf_FieldDescriptorProto_set_type(google_protobuf_FieldDescriptorProto *msg, google_protobuf_FieldDescriptorProto_Type value);
-void google_protobuf_FieldDescriptorProto_set_type_name(google_protobuf_FieldDescriptorProto *msg, upb_stringview value);
-void google_protobuf_FieldDescriptorProto_set_default_value(google_protobuf_FieldDescriptorProto *msg, upb_stringview value);
-void google_protobuf_FieldDescriptorProto_set_options(google_protobuf_FieldDescriptorProto *msg, google_protobuf_FieldOptions* value);
-void google_protobuf_FieldDescriptorProto_set_oneof_index(google_protobuf_FieldDescriptorProto *msg, int32_t value);
-void google_protobuf_FieldDescriptorProto_set_json_name(google_protobuf_FieldDescriptorProto *msg, upb_stringview value);
-
-
-/* google_protobuf_OneofDescriptorProto */
 extern const upb_msglayout google_protobuf_OneofDescriptorProto_msginit;
-google_protobuf_OneofDescriptorProto *google_protobuf_OneofDescriptorProto_new(upb_env *env);
-google_protobuf_OneofDescriptorProto *google_protobuf_OneofDescriptorProto_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_OneofDescriptorProto_serialize(google_protobuf_OneofDescriptorProto *msg, upb_env *env, size_t *len);
-void google_protobuf_OneofDescriptorProto_free(google_protobuf_OneofDescriptorProto *msg, upb_env *env);
+UPB_INLINE google_protobuf_OneofDescriptorProto *google_protobuf_OneofDescriptorProto_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_OneofDescriptorProto_msginit, arena);
+}
+UPB_INLINE google_protobuf_OneofDescriptorProto *google_protobuf_OneofDescriptorProto_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_OneofDescriptorProto *ret = google_protobuf_OneofDescriptorProto_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_OneofDescriptorProto_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_OneofDescriptorProto_serialize(const google_protobuf_OneofDescriptorProto *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_OneofDescriptorProto_msginit, arena, len);
+}
 
-/* getters. */
-upb_stringview google_protobuf_OneofDescriptorProto_name(const google_protobuf_OneofDescriptorProto *msg);
-const google_protobuf_OneofOptions* google_protobuf_OneofDescriptorProto_options(const google_protobuf_OneofDescriptorProto *msg);
+struct google_protobuf_EnumDescriptorProto {
+  struct {
+    bool name:1;
+    bool options:1;
+  } has;
+  upb_stringview name;
+  google_protobuf_EnumOptions* options;
+  upb_array* value;
+  upb_array* reserved_range;
+  upb_array* reserved_name;
+};
 
-/* setters. */
-void google_protobuf_OneofDescriptorProto_set_name(google_protobuf_OneofDescriptorProto *msg, upb_stringview value);
-void google_protobuf_OneofDescriptorProto_set_options(google_protobuf_OneofDescriptorProto *msg, google_protobuf_OneofOptions* value);
-
-
-/* google_protobuf_EnumDescriptorProto */
 extern const upb_msglayout google_protobuf_EnumDescriptorProto_msginit;
-google_protobuf_EnumDescriptorProto *google_protobuf_EnumDescriptorProto_new(upb_env *env);
-google_protobuf_EnumDescriptorProto *google_protobuf_EnumDescriptorProto_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_EnumDescriptorProto_serialize(google_protobuf_EnumDescriptorProto *msg, upb_env *env, size_t *len);
-void google_protobuf_EnumDescriptorProto_free(google_protobuf_EnumDescriptorProto *msg, upb_env *env);
+UPB_INLINE google_protobuf_EnumDescriptorProto *google_protobuf_EnumDescriptorProto_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_EnumDescriptorProto_msginit, arena);
+}
+UPB_INLINE google_protobuf_EnumDescriptorProto *google_protobuf_EnumDescriptorProto_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_EnumDescriptorProto *ret = google_protobuf_EnumDescriptorProto_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_EnumDescriptorProto_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_EnumDescriptorProto_serialize(const google_protobuf_EnumDescriptorProto *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_EnumDescriptorProto_msginit, arena, len);
+}
 
-/* getters. */
-upb_stringview google_protobuf_EnumDescriptorProto_name(const google_protobuf_EnumDescriptorProto *msg);
-const upb_array* google_protobuf_EnumDescriptorProto_value(const google_protobuf_EnumDescriptorProto *msg);
-const google_protobuf_EnumOptions* google_protobuf_EnumDescriptorProto_options(const google_protobuf_EnumDescriptorProto *msg);
-const upb_array* google_protobuf_EnumDescriptorProto_reserved_range(const google_protobuf_EnumDescriptorProto *msg);
-const upb_array* google_protobuf_EnumDescriptorProto_reserved_name(const google_protobuf_EnumDescriptorProto *msg);
+struct google_protobuf_EnumDescriptorProto_EnumReservedRange {
+  struct {
+    bool start:1;
+    bool end:1;
+  } has;
+  int32_t start;
+  int32_t end;
+};
 
-/* setters. */
-void google_protobuf_EnumDescriptorProto_set_name(google_protobuf_EnumDescriptorProto *msg, upb_stringview value);
-void google_protobuf_EnumDescriptorProto_set_value(google_protobuf_EnumDescriptorProto *msg, upb_array* value);
-void google_protobuf_EnumDescriptorProto_set_options(google_protobuf_EnumDescriptorProto *msg, google_protobuf_EnumOptions* value);
-void google_protobuf_EnumDescriptorProto_set_reserved_range(google_protobuf_EnumDescriptorProto *msg, upb_array* value);
-void google_protobuf_EnumDescriptorProto_set_reserved_name(google_protobuf_EnumDescriptorProto *msg, upb_array* value);
-
-
-/* google_protobuf_EnumDescriptorProto_EnumReservedRange */
 extern const upb_msglayout google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit;
-google_protobuf_EnumDescriptorProto_EnumReservedRange *google_protobuf_EnumDescriptorProto_EnumReservedRange_new(upb_env *env);
-google_protobuf_EnumDescriptorProto_EnumReservedRange *google_protobuf_EnumDescriptorProto_EnumReservedRange_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_EnumDescriptorProto_EnumReservedRange_serialize(google_protobuf_EnumDescriptorProto_EnumReservedRange *msg, upb_env *env, size_t *len);
-void google_protobuf_EnumDescriptorProto_EnumReservedRange_free(google_protobuf_EnumDescriptorProto_EnumReservedRange *msg, upb_env *env);
+UPB_INLINE google_protobuf_EnumDescriptorProto_EnumReservedRange *google_protobuf_EnumDescriptorProto_EnumReservedRange_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit, arena);
+}
+UPB_INLINE google_protobuf_EnumDescriptorProto_EnumReservedRange *google_protobuf_EnumDescriptorProto_EnumReservedRange_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_EnumDescriptorProto_EnumReservedRange *ret = google_protobuf_EnumDescriptorProto_EnumReservedRange_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_EnumDescriptorProto_EnumReservedRange_serialize(const google_protobuf_EnumDescriptorProto_EnumReservedRange *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_EnumDescriptorProto_EnumReservedRange_msginit, arena, len);
+}
 
-/* getters. */
-int32_t google_protobuf_EnumDescriptorProto_EnumReservedRange_start(const google_protobuf_EnumDescriptorProto_EnumReservedRange *msg);
-int32_t google_protobuf_EnumDescriptorProto_EnumReservedRange_end(const google_protobuf_EnumDescriptorProto_EnumReservedRange *msg);
+struct google_protobuf_EnumValueDescriptorProto {
+  struct {
+    bool number:1;
+    bool name:1;
+    bool options:1;
+  } has;
+  int32_t number;
+  upb_stringview name;
+  google_protobuf_EnumValueOptions* options;
+};
 
-/* setters. */
-void google_protobuf_EnumDescriptorProto_EnumReservedRange_set_start(google_protobuf_EnumDescriptorProto_EnumReservedRange *msg, int32_t value);
-void google_protobuf_EnumDescriptorProto_EnumReservedRange_set_end(google_protobuf_EnumDescriptorProto_EnumReservedRange *msg, int32_t value);
-
-
-/* google_protobuf_EnumValueDescriptorProto */
 extern const upb_msglayout google_protobuf_EnumValueDescriptorProto_msginit;
-google_protobuf_EnumValueDescriptorProto *google_protobuf_EnumValueDescriptorProto_new(upb_env *env);
-google_protobuf_EnumValueDescriptorProto *google_protobuf_EnumValueDescriptorProto_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_EnumValueDescriptorProto_serialize(google_protobuf_EnumValueDescriptorProto *msg, upb_env *env, size_t *len);
-void google_protobuf_EnumValueDescriptorProto_free(google_protobuf_EnumValueDescriptorProto *msg, upb_env *env);
+UPB_INLINE google_protobuf_EnumValueDescriptorProto *google_protobuf_EnumValueDescriptorProto_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_EnumValueDescriptorProto_msginit, arena);
+}
+UPB_INLINE google_protobuf_EnumValueDescriptorProto *google_protobuf_EnumValueDescriptorProto_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_EnumValueDescriptorProto *ret = google_protobuf_EnumValueDescriptorProto_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_EnumValueDescriptorProto_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_EnumValueDescriptorProto_serialize(const google_protobuf_EnumValueDescriptorProto *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_EnumValueDescriptorProto_msginit, arena, len);
+}
 
-/* getters. */
-upb_stringview google_protobuf_EnumValueDescriptorProto_name(const google_protobuf_EnumValueDescriptorProto *msg);
-int32_t google_protobuf_EnumValueDescriptorProto_number(const google_protobuf_EnumValueDescriptorProto *msg);
-const google_protobuf_EnumValueOptions* google_protobuf_EnumValueDescriptorProto_options(const google_protobuf_EnumValueDescriptorProto *msg);
+struct google_protobuf_ServiceDescriptorProto {
+  struct {
+    bool name:1;
+    bool options:1;
+  } has;
+  upb_stringview name;
+  google_protobuf_ServiceOptions* options;
+  upb_array* method;
+};
 
-/* setters. */
-void google_protobuf_EnumValueDescriptorProto_set_name(google_protobuf_EnumValueDescriptorProto *msg, upb_stringview value);
-void google_protobuf_EnumValueDescriptorProto_set_number(google_protobuf_EnumValueDescriptorProto *msg, int32_t value);
-void google_protobuf_EnumValueDescriptorProto_set_options(google_protobuf_EnumValueDescriptorProto *msg, google_protobuf_EnumValueOptions* value);
-
-
-/* google_protobuf_ServiceDescriptorProto */
 extern const upb_msglayout google_protobuf_ServiceDescriptorProto_msginit;
-google_protobuf_ServiceDescriptorProto *google_protobuf_ServiceDescriptorProto_new(upb_env *env);
-google_protobuf_ServiceDescriptorProto *google_protobuf_ServiceDescriptorProto_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_ServiceDescriptorProto_serialize(google_protobuf_ServiceDescriptorProto *msg, upb_env *env, size_t *len);
-void google_protobuf_ServiceDescriptorProto_free(google_protobuf_ServiceDescriptorProto *msg, upb_env *env);
+UPB_INLINE google_protobuf_ServiceDescriptorProto *google_protobuf_ServiceDescriptorProto_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_ServiceDescriptorProto_msginit, arena);
+}
+UPB_INLINE google_protobuf_ServiceDescriptorProto *google_protobuf_ServiceDescriptorProto_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_ServiceDescriptorProto *ret = google_protobuf_ServiceDescriptorProto_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_ServiceDescriptorProto_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_ServiceDescriptorProto_serialize(const google_protobuf_ServiceDescriptorProto *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_ServiceDescriptorProto_msginit, arena, len);
+}
 
-/* getters. */
-upb_stringview google_protobuf_ServiceDescriptorProto_name(const google_protobuf_ServiceDescriptorProto *msg);
-const upb_array* google_protobuf_ServiceDescriptorProto_method(const google_protobuf_ServiceDescriptorProto *msg);
-const google_protobuf_ServiceOptions* google_protobuf_ServiceDescriptorProto_options(const google_protobuf_ServiceDescriptorProto *msg);
+struct google_protobuf_MethodDescriptorProto {
+  struct {
+    bool client_streaming:1;
+    bool server_streaming:1;
+    bool name:1;
+    bool input_type:1;
+    bool output_type:1;
+    bool options:1;
+  } has;
+  bool client_streaming;
+  bool server_streaming;
+  upb_stringview name;
+  upb_stringview input_type;
+  upb_stringview output_type;
+  google_protobuf_MethodOptions* options;
+};
 
-/* setters. */
-void google_protobuf_ServiceDescriptorProto_set_name(google_protobuf_ServiceDescriptorProto *msg, upb_stringview value);
-void google_protobuf_ServiceDescriptorProto_set_method(google_protobuf_ServiceDescriptorProto *msg, upb_array* value);
-void google_protobuf_ServiceDescriptorProto_set_options(google_protobuf_ServiceDescriptorProto *msg, google_protobuf_ServiceOptions* value);
-
-
-/* google_protobuf_MethodDescriptorProto */
 extern const upb_msglayout google_protobuf_MethodDescriptorProto_msginit;
-google_protobuf_MethodDescriptorProto *google_protobuf_MethodDescriptorProto_new(upb_env *env);
-google_protobuf_MethodDescriptorProto *google_protobuf_MethodDescriptorProto_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_MethodDescriptorProto_serialize(google_protobuf_MethodDescriptorProto *msg, upb_env *env, size_t *len);
-void google_protobuf_MethodDescriptorProto_free(google_protobuf_MethodDescriptorProto *msg, upb_env *env);
+UPB_INLINE google_protobuf_MethodDescriptorProto *google_protobuf_MethodDescriptorProto_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_MethodDescriptorProto_msginit, arena);
+}
+UPB_INLINE google_protobuf_MethodDescriptorProto *google_protobuf_MethodDescriptorProto_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_MethodDescriptorProto *ret = google_protobuf_MethodDescriptorProto_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_MethodDescriptorProto_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_MethodDescriptorProto_serialize(const google_protobuf_MethodDescriptorProto *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_MethodDescriptorProto_msginit, arena, len);
+}
 
-/* getters. */
-upb_stringview google_protobuf_MethodDescriptorProto_name(const google_protobuf_MethodDescriptorProto *msg);
-upb_stringview google_protobuf_MethodDescriptorProto_input_type(const google_protobuf_MethodDescriptorProto *msg);
-upb_stringview google_protobuf_MethodDescriptorProto_output_type(const google_protobuf_MethodDescriptorProto *msg);
-const google_protobuf_MethodOptions* google_protobuf_MethodDescriptorProto_options(const google_protobuf_MethodDescriptorProto *msg);
-bool google_protobuf_MethodDescriptorProto_client_streaming(const google_protobuf_MethodDescriptorProto *msg);
-bool google_protobuf_MethodDescriptorProto_server_streaming(const google_protobuf_MethodDescriptorProto *msg);
+struct google_protobuf_FileOptions {
+  struct {
+    bool optimize_for:1;
+    bool java_multiple_files:1;
+    bool cc_generic_services:1;
+    bool java_generic_services:1;
+    bool py_generic_services:1;
+    bool java_generate_equals_and_hash:1;
+    bool deprecated:1;
+    bool java_string_check_utf8:1;
+    bool cc_enable_arenas:1;
+    bool php_generic_services:1;
+    bool java_package:1;
+    bool java_outer_classname:1;
+    bool go_package:1;
+    bool objc_class_prefix:1;
+    bool csharp_namespace:1;
+    bool swift_prefix:1;
+    bool php_class_prefix:1;
+    bool php_namespace:1;
+  } has;
+  google_protobuf_FileOptions_OptimizeMode optimize_for;
+  bool java_multiple_files;
+  bool cc_generic_services;
+  bool java_generic_services;
+  bool py_generic_services;
+  bool java_generate_equals_and_hash;
+  bool deprecated;
+  bool java_string_check_utf8;
+  bool cc_enable_arenas;
+  bool php_generic_services;
+  upb_stringview java_package;
+  upb_stringview java_outer_classname;
+  upb_stringview go_package;
+  upb_stringview objc_class_prefix;
+  upb_stringview csharp_namespace;
+  upb_stringview swift_prefix;
+  upb_stringview php_class_prefix;
+  upb_stringview php_namespace;
+  upb_array* uninterpreted_option;
+};
 
-/* setters. */
-void google_protobuf_MethodDescriptorProto_set_name(google_protobuf_MethodDescriptorProto *msg, upb_stringview value);
-void google_protobuf_MethodDescriptorProto_set_input_type(google_protobuf_MethodDescriptorProto *msg, upb_stringview value);
-void google_protobuf_MethodDescriptorProto_set_output_type(google_protobuf_MethodDescriptorProto *msg, upb_stringview value);
-void google_protobuf_MethodDescriptorProto_set_options(google_protobuf_MethodDescriptorProto *msg, google_protobuf_MethodOptions* value);
-void google_protobuf_MethodDescriptorProto_set_client_streaming(google_protobuf_MethodDescriptorProto *msg, bool value);
-void google_protobuf_MethodDescriptorProto_set_server_streaming(google_protobuf_MethodDescriptorProto *msg, bool value);
-
-
-/* google_protobuf_FileOptions */
 extern const upb_msglayout google_protobuf_FileOptions_msginit;
-google_protobuf_FileOptions *google_protobuf_FileOptions_new(upb_env *env);
-google_protobuf_FileOptions *google_protobuf_FileOptions_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_FileOptions_serialize(google_protobuf_FileOptions *msg, upb_env *env, size_t *len);
-void google_protobuf_FileOptions_free(google_protobuf_FileOptions *msg, upb_env *env);
+UPB_INLINE google_protobuf_FileOptions *google_protobuf_FileOptions_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_FileOptions_msginit, arena);
+}
+UPB_INLINE google_protobuf_FileOptions *google_protobuf_FileOptions_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_FileOptions *ret = google_protobuf_FileOptions_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_FileOptions_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_FileOptions_serialize(const google_protobuf_FileOptions *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_FileOptions_msginit, arena, len);
+}
 
-/* getters. */
-upb_stringview google_protobuf_FileOptions_java_package(const google_protobuf_FileOptions *msg);
-upb_stringview google_protobuf_FileOptions_java_outer_classname(const google_protobuf_FileOptions *msg);
-google_protobuf_FileOptions_OptimizeMode google_protobuf_FileOptions_optimize_for(const google_protobuf_FileOptions *msg);
-bool google_protobuf_FileOptions_java_multiple_files(const google_protobuf_FileOptions *msg);
-upb_stringview google_protobuf_FileOptions_go_package(const google_protobuf_FileOptions *msg);
-bool google_protobuf_FileOptions_cc_generic_services(const google_protobuf_FileOptions *msg);
-bool google_protobuf_FileOptions_java_generic_services(const google_protobuf_FileOptions *msg);
-bool google_protobuf_FileOptions_py_generic_services(const google_protobuf_FileOptions *msg);
-bool google_protobuf_FileOptions_java_generate_equals_and_hash(const google_protobuf_FileOptions *msg);
-bool google_protobuf_FileOptions_deprecated(const google_protobuf_FileOptions *msg);
-bool google_protobuf_FileOptions_java_string_check_utf8(const google_protobuf_FileOptions *msg);
-bool google_protobuf_FileOptions_cc_enable_arenas(const google_protobuf_FileOptions *msg);
-upb_stringview google_protobuf_FileOptions_objc_class_prefix(const google_protobuf_FileOptions *msg);
-upb_stringview google_protobuf_FileOptions_csharp_namespace(const google_protobuf_FileOptions *msg);
-upb_stringview google_protobuf_FileOptions_swift_prefix(const google_protobuf_FileOptions *msg);
-upb_stringview google_protobuf_FileOptions_php_class_prefix(const google_protobuf_FileOptions *msg);
-upb_stringview google_protobuf_FileOptions_php_namespace(const google_protobuf_FileOptions *msg);
-bool google_protobuf_FileOptions_php_generic_services(const google_protobuf_FileOptions *msg);
-const upb_array* google_protobuf_FileOptions_uninterpreted_option(const google_protobuf_FileOptions *msg);
+struct google_protobuf_MessageOptions {
+  struct {
+    bool message_set_wire_format:1;
+    bool no_standard_descriptor_accessor:1;
+    bool deprecated:1;
+    bool map_entry:1;
+  } has;
+  bool message_set_wire_format;
+  bool no_standard_descriptor_accessor;
+  bool deprecated;
+  bool map_entry;
+  upb_array* uninterpreted_option;
+};
 
-/* setters. */
-void google_protobuf_FileOptions_set_java_package(google_protobuf_FileOptions *msg, upb_stringview value);
-void google_protobuf_FileOptions_set_java_outer_classname(google_protobuf_FileOptions *msg, upb_stringview value);
-void google_protobuf_FileOptions_set_optimize_for(google_protobuf_FileOptions *msg, google_protobuf_FileOptions_OptimizeMode value);
-void google_protobuf_FileOptions_set_java_multiple_files(google_protobuf_FileOptions *msg, bool value);
-void google_protobuf_FileOptions_set_go_package(google_protobuf_FileOptions *msg, upb_stringview value);
-void google_protobuf_FileOptions_set_cc_generic_services(google_protobuf_FileOptions *msg, bool value);
-void google_protobuf_FileOptions_set_java_generic_services(google_protobuf_FileOptions *msg, bool value);
-void google_protobuf_FileOptions_set_py_generic_services(google_protobuf_FileOptions *msg, bool value);
-void google_protobuf_FileOptions_set_java_generate_equals_and_hash(google_protobuf_FileOptions *msg, bool value);
-void google_protobuf_FileOptions_set_deprecated(google_protobuf_FileOptions *msg, bool value);
-void google_protobuf_FileOptions_set_java_string_check_utf8(google_protobuf_FileOptions *msg, bool value);
-void google_protobuf_FileOptions_set_cc_enable_arenas(google_protobuf_FileOptions *msg, bool value);
-void google_protobuf_FileOptions_set_objc_class_prefix(google_protobuf_FileOptions *msg, upb_stringview value);
-void google_protobuf_FileOptions_set_csharp_namespace(google_protobuf_FileOptions *msg, upb_stringview value);
-void google_protobuf_FileOptions_set_swift_prefix(google_protobuf_FileOptions *msg, upb_stringview value);
-void google_protobuf_FileOptions_set_php_class_prefix(google_protobuf_FileOptions *msg, upb_stringview value);
-void google_protobuf_FileOptions_set_php_namespace(google_protobuf_FileOptions *msg, upb_stringview value);
-void google_protobuf_FileOptions_set_php_generic_services(google_protobuf_FileOptions *msg, bool value);
-void google_protobuf_FileOptions_set_uninterpreted_option(google_protobuf_FileOptions *msg, upb_array* value);
-
-
-/* google_protobuf_MessageOptions */
 extern const upb_msglayout google_protobuf_MessageOptions_msginit;
-google_protobuf_MessageOptions *google_protobuf_MessageOptions_new(upb_env *env);
-google_protobuf_MessageOptions *google_protobuf_MessageOptions_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_MessageOptions_serialize(google_protobuf_MessageOptions *msg, upb_env *env, size_t *len);
-void google_protobuf_MessageOptions_free(google_protobuf_MessageOptions *msg, upb_env *env);
+UPB_INLINE google_protobuf_MessageOptions *google_protobuf_MessageOptions_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_MessageOptions_msginit, arena);
+}
+UPB_INLINE google_protobuf_MessageOptions *google_protobuf_MessageOptions_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_MessageOptions *ret = google_protobuf_MessageOptions_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_MessageOptions_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_MessageOptions_serialize(const google_protobuf_MessageOptions *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_MessageOptions_msginit, arena, len);
+}
 
-/* getters. */
-bool google_protobuf_MessageOptions_message_set_wire_format(const google_protobuf_MessageOptions *msg);
-bool google_protobuf_MessageOptions_no_standard_descriptor_accessor(const google_protobuf_MessageOptions *msg);
-bool google_protobuf_MessageOptions_deprecated(const google_protobuf_MessageOptions *msg);
-bool google_protobuf_MessageOptions_map_entry(const google_protobuf_MessageOptions *msg);
-const upb_array* google_protobuf_MessageOptions_uninterpreted_option(const google_protobuf_MessageOptions *msg);
+struct google_protobuf_FieldOptions {
+  struct {
+    bool ctype:1;
+    bool jstype:1;
+    bool packed:1;
+    bool deprecated:1;
+    bool lazy:1;
+    bool weak:1;
+  } has;
+  google_protobuf_FieldOptions_CType ctype;
+  google_protobuf_FieldOptions_JSType jstype;
+  bool packed;
+  bool deprecated;
+  bool lazy;
+  bool weak;
+  upb_array* uninterpreted_option;
+};
 
-/* setters. */
-void google_protobuf_MessageOptions_set_message_set_wire_format(google_protobuf_MessageOptions *msg, bool value);
-void google_protobuf_MessageOptions_set_no_standard_descriptor_accessor(google_protobuf_MessageOptions *msg, bool value);
-void google_protobuf_MessageOptions_set_deprecated(google_protobuf_MessageOptions *msg, bool value);
-void google_protobuf_MessageOptions_set_map_entry(google_protobuf_MessageOptions *msg, bool value);
-void google_protobuf_MessageOptions_set_uninterpreted_option(google_protobuf_MessageOptions *msg, upb_array* value);
-
-
-/* google_protobuf_FieldOptions */
 extern const upb_msglayout google_protobuf_FieldOptions_msginit;
-google_protobuf_FieldOptions *google_protobuf_FieldOptions_new(upb_env *env);
-google_protobuf_FieldOptions *google_protobuf_FieldOptions_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_FieldOptions_serialize(google_protobuf_FieldOptions *msg, upb_env *env, size_t *len);
-void google_protobuf_FieldOptions_free(google_protobuf_FieldOptions *msg, upb_env *env);
+UPB_INLINE google_protobuf_FieldOptions *google_protobuf_FieldOptions_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_FieldOptions_msginit, arena);
+}
+UPB_INLINE google_protobuf_FieldOptions *google_protobuf_FieldOptions_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_FieldOptions *ret = google_protobuf_FieldOptions_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_FieldOptions_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_FieldOptions_serialize(const google_protobuf_FieldOptions *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_FieldOptions_msginit, arena, len);
+}
 
-/* getters. */
-google_protobuf_FieldOptions_CType google_protobuf_FieldOptions_ctype(const google_protobuf_FieldOptions *msg);
-bool google_protobuf_FieldOptions_packed(const google_protobuf_FieldOptions *msg);
-bool google_protobuf_FieldOptions_deprecated(const google_protobuf_FieldOptions *msg);
-bool google_protobuf_FieldOptions_lazy(const google_protobuf_FieldOptions *msg);
-google_protobuf_FieldOptions_JSType google_protobuf_FieldOptions_jstype(const google_protobuf_FieldOptions *msg);
-bool google_protobuf_FieldOptions_weak(const google_protobuf_FieldOptions *msg);
-const upb_array* google_protobuf_FieldOptions_uninterpreted_option(const google_protobuf_FieldOptions *msg);
+struct google_protobuf_OneofOptions {
+  upb_array* uninterpreted_option;
+};
 
-/* setters. */
-void google_protobuf_FieldOptions_set_ctype(google_protobuf_FieldOptions *msg, google_protobuf_FieldOptions_CType value);
-void google_protobuf_FieldOptions_set_packed(google_protobuf_FieldOptions *msg, bool value);
-void google_protobuf_FieldOptions_set_deprecated(google_protobuf_FieldOptions *msg, bool value);
-void google_protobuf_FieldOptions_set_lazy(google_protobuf_FieldOptions *msg, bool value);
-void google_protobuf_FieldOptions_set_jstype(google_protobuf_FieldOptions *msg, google_protobuf_FieldOptions_JSType value);
-void google_protobuf_FieldOptions_set_weak(google_protobuf_FieldOptions *msg, bool value);
-void google_protobuf_FieldOptions_set_uninterpreted_option(google_protobuf_FieldOptions *msg, upb_array* value);
-
-
-/* google_protobuf_OneofOptions */
 extern const upb_msglayout google_protobuf_OneofOptions_msginit;
-google_protobuf_OneofOptions *google_protobuf_OneofOptions_new(upb_env *env);
-google_protobuf_OneofOptions *google_protobuf_OneofOptions_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_OneofOptions_serialize(google_protobuf_OneofOptions *msg, upb_env *env, size_t *len);
-void google_protobuf_OneofOptions_free(google_protobuf_OneofOptions *msg, upb_env *env);
+UPB_INLINE google_protobuf_OneofOptions *google_protobuf_OneofOptions_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_OneofOptions_msginit, arena);
+}
+UPB_INLINE google_protobuf_OneofOptions *google_protobuf_OneofOptions_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_OneofOptions *ret = google_protobuf_OneofOptions_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_OneofOptions_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_OneofOptions_serialize(const google_protobuf_OneofOptions *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_OneofOptions_msginit, arena, len);
+}
 
-/* getters. */
-const upb_array* google_protobuf_OneofOptions_uninterpreted_option(const google_protobuf_OneofOptions *msg);
+struct google_protobuf_EnumOptions {
+  struct {
+    bool allow_alias:1;
+    bool deprecated:1;
+  } has;
+  bool allow_alias;
+  bool deprecated;
+  upb_array* uninterpreted_option;
+};
 
-/* setters. */
-void google_protobuf_OneofOptions_set_uninterpreted_option(google_protobuf_OneofOptions *msg, upb_array* value);
-
-
-/* google_protobuf_EnumOptions */
 extern const upb_msglayout google_protobuf_EnumOptions_msginit;
-google_protobuf_EnumOptions *google_protobuf_EnumOptions_new(upb_env *env);
-google_protobuf_EnumOptions *google_protobuf_EnumOptions_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_EnumOptions_serialize(google_protobuf_EnumOptions *msg, upb_env *env, size_t *len);
-void google_protobuf_EnumOptions_free(google_protobuf_EnumOptions *msg, upb_env *env);
+UPB_INLINE google_protobuf_EnumOptions *google_protobuf_EnumOptions_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_EnumOptions_msginit, arena);
+}
+UPB_INLINE google_protobuf_EnumOptions *google_protobuf_EnumOptions_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_EnumOptions *ret = google_protobuf_EnumOptions_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_EnumOptions_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_EnumOptions_serialize(const google_protobuf_EnumOptions *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_EnumOptions_msginit, arena, len);
+}
 
-/* getters. */
-bool google_protobuf_EnumOptions_allow_alias(const google_protobuf_EnumOptions *msg);
-bool google_protobuf_EnumOptions_deprecated(const google_protobuf_EnumOptions *msg);
-const upb_array* google_protobuf_EnumOptions_uninterpreted_option(const google_protobuf_EnumOptions *msg);
+struct google_protobuf_EnumValueOptions {
+  struct {
+    bool deprecated:1;
+  } has;
+  bool deprecated;
+  upb_array* uninterpreted_option;
+};
 
-/* setters. */
-void google_protobuf_EnumOptions_set_allow_alias(google_protobuf_EnumOptions *msg, bool value);
-void google_protobuf_EnumOptions_set_deprecated(google_protobuf_EnumOptions *msg, bool value);
-void google_protobuf_EnumOptions_set_uninterpreted_option(google_protobuf_EnumOptions *msg, upb_array* value);
-
-
-/* google_protobuf_EnumValueOptions */
 extern const upb_msglayout google_protobuf_EnumValueOptions_msginit;
-google_protobuf_EnumValueOptions *google_protobuf_EnumValueOptions_new(upb_env *env);
-google_protobuf_EnumValueOptions *google_protobuf_EnumValueOptions_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_EnumValueOptions_serialize(google_protobuf_EnumValueOptions *msg, upb_env *env, size_t *len);
-void google_protobuf_EnumValueOptions_free(google_protobuf_EnumValueOptions *msg, upb_env *env);
+UPB_INLINE google_protobuf_EnumValueOptions *google_protobuf_EnumValueOptions_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_EnumValueOptions_msginit, arena);
+}
+UPB_INLINE google_protobuf_EnumValueOptions *google_protobuf_EnumValueOptions_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_EnumValueOptions *ret = google_protobuf_EnumValueOptions_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_EnumValueOptions_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_EnumValueOptions_serialize(const google_protobuf_EnumValueOptions *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_EnumValueOptions_msginit, arena, len);
+}
 
-/* getters. */
-bool google_protobuf_EnumValueOptions_deprecated(const google_protobuf_EnumValueOptions *msg);
-const upb_array* google_protobuf_EnumValueOptions_uninterpreted_option(const google_protobuf_EnumValueOptions *msg);
+struct google_protobuf_ServiceOptions {
+  struct {
+    bool deprecated:1;
+  } has;
+  bool deprecated;
+  upb_array* uninterpreted_option;
+};
 
-/* setters. */
-void google_protobuf_EnumValueOptions_set_deprecated(google_protobuf_EnumValueOptions *msg, bool value);
-void google_protobuf_EnumValueOptions_set_uninterpreted_option(google_protobuf_EnumValueOptions *msg, upb_array* value);
-
-
-/* google_protobuf_ServiceOptions */
 extern const upb_msglayout google_protobuf_ServiceOptions_msginit;
-google_protobuf_ServiceOptions *google_protobuf_ServiceOptions_new(upb_env *env);
-google_protobuf_ServiceOptions *google_protobuf_ServiceOptions_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_ServiceOptions_serialize(google_protobuf_ServiceOptions *msg, upb_env *env, size_t *len);
-void google_protobuf_ServiceOptions_free(google_protobuf_ServiceOptions *msg, upb_env *env);
+UPB_INLINE google_protobuf_ServiceOptions *google_protobuf_ServiceOptions_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_ServiceOptions_msginit, arena);
+}
+UPB_INLINE google_protobuf_ServiceOptions *google_protobuf_ServiceOptions_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_ServiceOptions *ret = google_protobuf_ServiceOptions_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_ServiceOptions_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_ServiceOptions_serialize(const google_protobuf_ServiceOptions *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_ServiceOptions_msginit, arena, len);
+}
 
-/* getters. */
-bool google_protobuf_ServiceOptions_deprecated(const google_protobuf_ServiceOptions *msg);
-const upb_array* google_protobuf_ServiceOptions_uninterpreted_option(const google_protobuf_ServiceOptions *msg);
+struct google_protobuf_MethodOptions {
+  struct {
+    bool idempotency_level:1;
+    bool deprecated:1;
+  } has;
+  google_protobuf_MethodOptions_IdempotencyLevel idempotency_level;
+  bool deprecated;
+  upb_array* uninterpreted_option;
+};
 
-/* setters. */
-void google_protobuf_ServiceOptions_set_deprecated(google_protobuf_ServiceOptions *msg, bool value);
-void google_protobuf_ServiceOptions_set_uninterpreted_option(google_protobuf_ServiceOptions *msg, upb_array* value);
-
-
-/* google_protobuf_MethodOptions */
 extern const upb_msglayout google_protobuf_MethodOptions_msginit;
-google_protobuf_MethodOptions *google_protobuf_MethodOptions_new(upb_env *env);
-google_protobuf_MethodOptions *google_protobuf_MethodOptions_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_MethodOptions_serialize(google_protobuf_MethodOptions *msg, upb_env *env, size_t *len);
-void google_protobuf_MethodOptions_free(google_protobuf_MethodOptions *msg, upb_env *env);
+UPB_INLINE google_protobuf_MethodOptions *google_protobuf_MethodOptions_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_MethodOptions_msginit, arena);
+}
+UPB_INLINE google_protobuf_MethodOptions *google_protobuf_MethodOptions_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_MethodOptions *ret = google_protobuf_MethodOptions_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_MethodOptions_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_MethodOptions_serialize(const google_protobuf_MethodOptions *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_MethodOptions_msginit, arena, len);
+}
 
-/* getters. */
-bool google_protobuf_MethodOptions_deprecated(const google_protobuf_MethodOptions *msg);
-google_protobuf_MethodOptions_IdempotencyLevel google_protobuf_MethodOptions_idempotency_level(const google_protobuf_MethodOptions *msg);
-const upb_array* google_protobuf_MethodOptions_uninterpreted_option(const google_protobuf_MethodOptions *msg);
+struct google_protobuf_UninterpretedOption {
+  struct {
+    bool positive_int_value:1;
+    bool negative_int_value:1;
+    bool double_value:1;
+    bool identifier_value:1;
+    bool string_value:1;
+    bool aggregate_value:1;
+  } has;
+  uint64_t positive_int_value;
+  int64_t negative_int_value;
+  double double_value;
+  upb_stringview identifier_value;
+  upb_stringview string_value;
+  upb_stringview aggregate_value;
+  upb_array* name;
+};
 
-/* setters. */
-void google_protobuf_MethodOptions_set_deprecated(google_protobuf_MethodOptions *msg, bool value);
-void google_protobuf_MethodOptions_set_idempotency_level(google_protobuf_MethodOptions *msg, google_protobuf_MethodOptions_IdempotencyLevel value);
-void google_protobuf_MethodOptions_set_uninterpreted_option(google_protobuf_MethodOptions *msg, upb_array* value);
-
-
-/* google_protobuf_UninterpretedOption */
 extern const upb_msglayout google_protobuf_UninterpretedOption_msginit;
-google_protobuf_UninterpretedOption *google_protobuf_UninterpretedOption_new(upb_env *env);
-google_protobuf_UninterpretedOption *google_protobuf_UninterpretedOption_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_UninterpretedOption_serialize(google_protobuf_UninterpretedOption *msg, upb_env *env, size_t *len);
-void google_protobuf_UninterpretedOption_free(google_protobuf_UninterpretedOption *msg, upb_env *env);
+UPB_INLINE google_protobuf_UninterpretedOption *google_protobuf_UninterpretedOption_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_UninterpretedOption_msginit, arena);
+}
+UPB_INLINE google_protobuf_UninterpretedOption *google_protobuf_UninterpretedOption_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_UninterpretedOption *ret = google_protobuf_UninterpretedOption_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_UninterpretedOption_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_UninterpretedOption_serialize(const google_protobuf_UninterpretedOption *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_UninterpretedOption_msginit, arena, len);
+}
 
-/* getters. */
-const upb_array* google_protobuf_UninterpretedOption_name(const google_protobuf_UninterpretedOption *msg);
-upb_stringview google_protobuf_UninterpretedOption_identifier_value(const google_protobuf_UninterpretedOption *msg);
-uint64_t google_protobuf_UninterpretedOption_positive_int_value(const google_protobuf_UninterpretedOption *msg);
-int64_t google_protobuf_UninterpretedOption_negative_int_value(const google_protobuf_UninterpretedOption *msg);
-double google_protobuf_UninterpretedOption_double_value(const google_protobuf_UninterpretedOption *msg);
-upb_stringview google_protobuf_UninterpretedOption_string_value(const google_protobuf_UninterpretedOption *msg);
-upb_stringview google_protobuf_UninterpretedOption_aggregate_value(const google_protobuf_UninterpretedOption *msg);
+struct google_protobuf_UninterpretedOption_NamePart {
+  struct {
+    bool is_extension:1;
+    bool name_part:1;
+  } has;
+  bool is_extension;
+  upb_stringview name_part;
+};
 
-/* setters. */
-void google_protobuf_UninterpretedOption_set_name(google_protobuf_UninterpretedOption *msg, upb_array* value);
-void google_protobuf_UninterpretedOption_set_identifier_value(google_protobuf_UninterpretedOption *msg, upb_stringview value);
-void google_protobuf_UninterpretedOption_set_positive_int_value(google_protobuf_UninterpretedOption *msg, uint64_t value);
-void google_protobuf_UninterpretedOption_set_negative_int_value(google_protobuf_UninterpretedOption *msg, int64_t value);
-void google_protobuf_UninterpretedOption_set_double_value(google_protobuf_UninterpretedOption *msg, double value);
-void google_protobuf_UninterpretedOption_set_string_value(google_protobuf_UninterpretedOption *msg, upb_stringview value);
-void google_protobuf_UninterpretedOption_set_aggregate_value(google_protobuf_UninterpretedOption *msg, upb_stringview value);
-
-
-/* google_protobuf_UninterpretedOption_NamePart */
 extern const upb_msglayout google_protobuf_UninterpretedOption_NamePart_msginit;
-google_protobuf_UninterpretedOption_NamePart *google_protobuf_UninterpretedOption_NamePart_new(upb_env *env);
-google_protobuf_UninterpretedOption_NamePart *google_protobuf_UninterpretedOption_NamePart_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_UninterpretedOption_NamePart_serialize(google_protobuf_UninterpretedOption_NamePart *msg, upb_env *env, size_t *len);
-void google_protobuf_UninterpretedOption_NamePart_free(google_protobuf_UninterpretedOption_NamePart *msg, upb_env *env);
+UPB_INLINE google_protobuf_UninterpretedOption_NamePart *google_protobuf_UninterpretedOption_NamePart_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_UninterpretedOption_NamePart_msginit, arena);
+}
+UPB_INLINE google_protobuf_UninterpretedOption_NamePart *google_protobuf_UninterpretedOption_NamePart_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_UninterpretedOption_NamePart *ret = google_protobuf_UninterpretedOption_NamePart_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_UninterpretedOption_NamePart_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_UninterpretedOption_NamePart_serialize(const google_protobuf_UninterpretedOption_NamePart *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_UninterpretedOption_NamePart_msginit, arena, len);
+}
 
-/* getters. */
-upb_stringview google_protobuf_UninterpretedOption_NamePart_name_part(const google_protobuf_UninterpretedOption_NamePart *msg);
-bool google_protobuf_UninterpretedOption_NamePart_is_extension(const google_protobuf_UninterpretedOption_NamePart *msg);
+struct google_protobuf_SourceCodeInfo {
+  upb_array* location;
+};
 
-/* setters. */
-void google_protobuf_UninterpretedOption_NamePart_set_name_part(google_protobuf_UninterpretedOption_NamePart *msg, upb_stringview value);
-void google_protobuf_UninterpretedOption_NamePart_set_is_extension(google_protobuf_UninterpretedOption_NamePart *msg, bool value);
-
-
-/* google_protobuf_SourceCodeInfo */
 extern const upb_msglayout google_protobuf_SourceCodeInfo_msginit;
-google_protobuf_SourceCodeInfo *google_protobuf_SourceCodeInfo_new(upb_env *env);
-google_protobuf_SourceCodeInfo *google_protobuf_SourceCodeInfo_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_SourceCodeInfo_serialize(google_protobuf_SourceCodeInfo *msg, upb_env *env, size_t *len);
-void google_protobuf_SourceCodeInfo_free(google_protobuf_SourceCodeInfo *msg, upb_env *env);
+UPB_INLINE google_protobuf_SourceCodeInfo *google_protobuf_SourceCodeInfo_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_SourceCodeInfo_msginit, arena);
+}
+UPB_INLINE google_protobuf_SourceCodeInfo *google_protobuf_SourceCodeInfo_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_SourceCodeInfo *ret = google_protobuf_SourceCodeInfo_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_SourceCodeInfo_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_SourceCodeInfo_serialize(const google_protobuf_SourceCodeInfo *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_SourceCodeInfo_msginit, arena, len);
+}
 
-/* getters. */
-const upb_array* google_protobuf_SourceCodeInfo_location(const google_protobuf_SourceCodeInfo *msg);
+struct google_protobuf_SourceCodeInfo_Location {
+  struct {
+    bool leading_comments:1;
+    bool trailing_comments:1;
+  } has;
+  upb_stringview leading_comments;
+  upb_stringview trailing_comments;
+  upb_array* path;
+  upb_array* span;
+  upb_array* leading_detached_comments;
+};
 
-/* setters. */
-void google_protobuf_SourceCodeInfo_set_location(google_protobuf_SourceCodeInfo *msg, upb_array* value);
-
-
-/* google_protobuf_SourceCodeInfo_Location */
 extern const upb_msglayout google_protobuf_SourceCodeInfo_Location_msginit;
-google_protobuf_SourceCodeInfo_Location *google_protobuf_SourceCodeInfo_Location_new(upb_env *env);
-google_protobuf_SourceCodeInfo_Location *google_protobuf_SourceCodeInfo_Location_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_SourceCodeInfo_Location_serialize(google_protobuf_SourceCodeInfo_Location *msg, upb_env *env, size_t *len);
-void google_protobuf_SourceCodeInfo_Location_free(google_protobuf_SourceCodeInfo_Location *msg, upb_env *env);
+UPB_INLINE google_protobuf_SourceCodeInfo_Location *google_protobuf_SourceCodeInfo_Location_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_SourceCodeInfo_Location_msginit, arena);
+}
+UPB_INLINE google_protobuf_SourceCodeInfo_Location *google_protobuf_SourceCodeInfo_Location_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_SourceCodeInfo_Location *ret = google_protobuf_SourceCodeInfo_Location_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_SourceCodeInfo_Location_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_SourceCodeInfo_Location_serialize(const google_protobuf_SourceCodeInfo_Location *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_SourceCodeInfo_Location_msginit, arena, len);
+}
 
-/* getters. */
-const upb_array* google_protobuf_SourceCodeInfo_Location_path(const google_protobuf_SourceCodeInfo_Location *msg);
-const upb_array* google_protobuf_SourceCodeInfo_Location_span(const google_protobuf_SourceCodeInfo_Location *msg);
-upb_stringview google_protobuf_SourceCodeInfo_Location_leading_comments(const google_protobuf_SourceCodeInfo_Location *msg);
-upb_stringview google_protobuf_SourceCodeInfo_Location_trailing_comments(const google_protobuf_SourceCodeInfo_Location *msg);
-const upb_array* google_protobuf_SourceCodeInfo_Location_leading_detached_comments(const google_protobuf_SourceCodeInfo_Location *msg);
+struct google_protobuf_GeneratedCodeInfo {
+  upb_array* annotation;
+};
 
-/* setters. */
-void google_protobuf_SourceCodeInfo_Location_set_path(google_protobuf_SourceCodeInfo_Location *msg, upb_array* value);
-void google_protobuf_SourceCodeInfo_Location_set_span(google_protobuf_SourceCodeInfo_Location *msg, upb_array* value);
-void google_protobuf_SourceCodeInfo_Location_set_leading_comments(google_protobuf_SourceCodeInfo_Location *msg, upb_stringview value);
-void google_protobuf_SourceCodeInfo_Location_set_trailing_comments(google_protobuf_SourceCodeInfo_Location *msg, upb_stringview value);
-void google_protobuf_SourceCodeInfo_Location_set_leading_detached_comments(google_protobuf_SourceCodeInfo_Location *msg, upb_array* value);
-
-
-/* google_protobuf_GeneratedCodeInfo */
 extern const upb_msglayout google_protobuf_GeneratedCodeInfo_msginit;
-google_protobuf_GeneratedCodeInfo *google_protobuf_GeneratedCodeInfo_new(upb_env *env);
-google_protobuf_GeneratedCodeInfo *google_protobuf_GeneratedCodeInfo_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_GeneratedCodeInfo_serialize(google_protobuf_GeneratedCodeInfo *msg, upb_env *env, size_t *len);
-void google_protobuf_GeneratedCodeInfo_free(google_protobuf_GeneratedCodeInfo *msg, upb_env *env);
+UPB_INLINE google_protobuf_GeneratedCodeInfo *google_protobuf_GeneratedCodeInfo_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_GeneratedCodeInfo_msginit, arena);
+}
+UPB_INLINE google_protobuf_GeneratedCodeInfo *google_protobuf_GeneratedCodeInfo_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_GeneratedCodeInfo *ret = google_protobuf_GeneratedCodeInfo_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_GeneratedCodeInfo_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_GeneratedCodeInfo_serialize(const google_protobuf_GeneratedCodeInfo *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_GeneratedCodeInfo_msginit, arena, len);
+}
 
-/* getters. */
-const upb_array* google_protobuf_GeneratedCodeInfo_annotation(const google_protobuf_GeneratedCodeInfo *msg);
+struct google_protobuf_GeneratedCodeInfo_Annotation {
+  struct {
+    bool begin:1;
+    bool end:1;
+    bool source_file:1;
+  } has;
+  int32_t begin;
+  int32_t end;
+  upb_stringview source_file;
+  upb_array* path;
+};
 
-/* setters. */
-void google_protobuf_GeneratedCodeInfo_set_annotation(google_protobuf_GeneratedCodeInfo *msg, upb_array* value);
-
-
-/* google_protobuf_GeneratedCodeInfo_Annotation */
 extern const upb_msglayout google_protobuf_GeneratedCodeInfo_Annotation_msginit;
-google_protobuf_GeneratedCodeInfo_Annotation *google_protobuf_GeneratedCodeInfo_Annotation_new(upb_env *env);
-google_protobuf_GeneratedCodeInfo_Annotation *google_protobuf_GeneratedCodeInfo_Annotation_parsenew(upb_stringview buf, upb_env *env);
-char *google_protobuf_GeneratedCodeInfo_Annotation_serialize(google_protobuf_GeneratedCodeInfo_Annotation *msg, upb_env *env, size_t *len);
-void google_protobuf_GeneratedCodeInfo_Annotation_free(google_protobuf_GeneratedCodeInfo_Annotation *msg, upb_env *env);
-
-/* getters. */
-const upb_array* google_protobuf_GeneratedCodeInfo_Annotation_path(const google_protobuf_GeneratedCodeInfo_Annotation *msg);
-upb_stringview google_protobuf_GeneratedCodeInfo_Annotation_source_file(const google_protobuf_GeneratedCodeInfo_Annotation *msg);
-int32_t google_protobuf_GeneratedCodeInfo_Annotation_begin(const google_protobuf_GeneratedCodeInfo_Annotation *msg);
-int32_t google_protobuf_GeneratedCodeInfo_Annotation_end(const google_protobuf_GeneratedCodeInfo_Annotation *msg);
-
-/* setters. */
-void google_protobuf_GeneratedCodeInfo_Annotation_set_path(google_protobuf_GeneratedCodeInfo_Annotation *msg, upb_array* value);
-void google_protobuf_GeneratedCodeInfo_Annotation_set_source_file(google_protobuf_GeneratedCodeInfo_Annotation *msg, upb_stringview value);
-void google_protobuf_GeneratedCodeInfo_Annotation_set_begin(google_protobuf_GeneratedCodeInfo_Annotation *msg, int32_t value);
-void google_protobuf_GeneratedCodeInfo_Annotation_set_end(google_protobuf_GeneratedCodeInfo_Annotation *msg, int32_t value);
-
+UPB_INLINE google_protobuf_GeneratedCodeInfo_Annotation *google_protobuf_GeneratedCodeInfo_Annotation_new(upb_arena *arena) {
+  return upb_msg_new(&google_protobuf_GeneratedCodeInfo_Annotation_msginit, arena);
+}
+UPB_INLINE google_protobuf_GeneratedCodeInfo_Annotation *google_protobuf_GeneratedCodeInfo_Annotation_parsenew(upb_stringview buf, upb_arena *arena) {
+  google_protobuf_GeneratedCodeInfo_Annotation *ret = google_protobuf_GeneratedCodeInfo_Annotation_new(arena);
+  return (ret && upb_decode(buf, ret, &google_protobuf_GeneratedCodeInfo_Annotation_msginit)) ? ret : NULL;
+}
+UPB_INLINE char *google_protobuf_GeneratedCodeInfo_Annotation_serialize(const google_protobuf_GeneratedCodeInfo_Annotation *msg, upb_arena *arena, size_t *len) {
+  return upb_encode(msg, &google_protobuf_GeneratedCodeInfo_Annotation_msginit, arena, len);
+}
 
 UPB_END_EXTERN_C
 

--- a/google/protobuf/descriptor.upb.h
+++ b/google/protobuf/descriptor.upb.h
@@ -43,6 +43,7 @@ typedef struct google_protobuf_SourceCodeInfo { int a; } google_protobuf_SourceC
 typedef struct google_protobuf_SourceCodeInfo_Location { int a; } google_protobuf_SourceCodeInfo_Location;
 typedef struct google_protobuf_GeneratedCodeInfo { int a; } google_protobuf_GeneratedCodeInfo;
 typedef struct google_protobuf_GeneratedCodeInfo_Annotation { int a; } google_protobuf_GeneratedCodeInfo_Annotation;
+
 /* Enums */
 
 typedef enum {
@@ -800,6 +801,7 @@ UPB_INLINE void google_protobuf_GeneratedCodeInfo_Annotation_set_end(google_prot
 
 
 UPB_END_EXTERN_C
+
 #include "upb/port_undef.inc"
 
 #endif  /* GOOGLE_PROTOBUF_DESCRIPTOR_PROTO_UPB_H_ */

--- a/tests/conformance_upb.c
+++ b/tests/conformance_upb.c
@@ -141,7 +141,7 @@ bool DoTestIo() {
   conformance_ConformanceResponse *response;
 
   if (!CheckedRead(STDIN_FILENO, &input_size, sizeof(uint32_t))) {
-    // EOF.
+    /* EOF. */
     return false;
   }
 

--- a/tests/conformance_upb.c
+++ b/tests/conformance_upb.c
@@ -49,30 +49,27 @@ static const char *proto3_msg =
 void DoTest(
     const conformance_ConformanceRequest* request,
     conformance_ConformanceResponse *response,
-    upb_env *env) {
-  upb_stringview message_type =
-      conformance_ConformanceRequest_message_type(request);
-  if (!stringview_eql(message_type, proto3_msg)) {
+    upb_arena *arena) {
+  if (!stringview_eql(request->message_type, proto3_msg)) {
     static const char msg[] = "Only proto3 for now.";
-    conformance_ConformanceResponse_set_skipped(
-        response, upb_stringview_make(msg, sizeof(msg)));
+    response->result_case = conformance_ConformanceResponse_result_skipped;
+    response->result.skipped = upb_stringview_make(msg, sizeof(msg));
     return;
   }
 
   protobuf_test_messages_proto3_TestAllTypesProto3 *test_message;
 
-  switch (conformance_ConformanceRequest_payload_case(request)) {
+  switch (request->payload_case) {
     case conformance_ConformanceRequest_payload_protobuf_payload: {
-      upb_stringview payload =
-          conformance_ConformanceRequest_protobuf_payload(request);
+      upb_stringview payload = request->payload.protobuf_payload;
       test_message = protobuf_test_messages_proto3_TestAllTypesProto3_parsenew(
-          payload, env);
+          payload, arena);
 
       if (!test_message) {
-        /* TODO(haberman): return details. */
-        static const char msg[] = "Parse error (no more details available).";
-        conformance_ConformanceResponse_set_parse_error(
-            response, upb_stringview_make(msg, sizeof(msg)));
+        static const char msg[] = "Parse error";
+        response->result_case =
+            conformance_ConformanceResponse_result_parse_error;
+        response->result.parse_error = upb_stringview_make(msg, sizeof(msg));
         return;
       }
       break;
@@ -80,8 +77,8 @@ void DoTest(
 
     case conformance_ConformanceRequest_payload_json_payload: {
       static const char msg[] = "JSON support not yet implemented.";
-      conformance_ConformanceResponse_set_skipped(
-          response, upb_stringview_make(msg, sizeof(msg)));
+      response->result_case = conformance_ConformanceResponse_result_skipped;
+      response->result.skipped = upb_stringview_make(msg, sizeof(msg));
       return;
     }
 
@@ -90,7 +87,7 @@ void DoTest(
       return;
   }
 
-  switch (conformance_ConformanceRequest_requested_output_format(request)) {
+  switch (request->requested_output_format) {
     case conformance_UNSPECIFIED:
       fprintf(stderr, "conformance_upb: Unspecified output format.\n");
       exit(1);
@@ -99,28 +96,32 @@ void DoTest(
       size_t serialized_len;
       char *serialized =
           protobuf_test_messages_proto3_TestAllTypesProto3_serialize(
-              test_message, env, &serialized_len);
+              test_message, arena, &serialized_len);
       if (!serialized) {
         static const char msg[] = "Error serializing.";
-        conformance_ConformanceResponse_set_serialize_error(
-            response, upb_stringview_make(msg, sizeof(msg)));
+        response->result_case =
+            conformance_ConformanceResponse_result_serialize_error;
+        response->result.serialize_error =
+            upb_stringview_make(msg, sizeof(msg));
         return;
       }
-      conformance_ConformanceResponse_set_protobuf_payload(
-          response, upb_stringview_make(serialized, serialized_len));
+      response->result_case =
+          conformance_ConformanceResponse_result_protobuf_payload;
+      response->result.protobuf_payload =
+          upb_stringview_make(serialized, serialized_len);
       break;
     }
 
     case conformance_JSON: {
       static const char msg[] = "JSON support not yet implemented.";
-      conformance_ConformanceResponse_set_skipped(
-          response, upb_stringview_make(msg, sizeof(msg)));
+      response->result_case = conformance_ConformanceResponse_result_skipped;
+      response->result.skipped = upb_stringview_make(msg, sizeof(msg));
       break;
     }
 
     default:
       fprintf(stderr, "conformance_upb: Unknown output format: %d\n",
-              conformance_ConformanceRequest_requested_output_format(request));
+              request->requested_output_format);
       exit(1);
   }
 
@@ -128,7 +129,8 @@ void DoTest(
 }
 
 bool DoTestIo() {
-  upb_env env;
+  upb_arena arena;
+  upb_alloc *alloc;
   upb_status status;
   char *serialized_input;
   char *serialized_output;
@@ -142,9 +144,9 @@ bool DoTestIo() {
     return false;
   }
 
-  upb_env_init(&env);
-  upb_env_reporterrorsto(&env, &status);
-  serialized_input = upb_env_malloc(&env, input_size);
+  upb_arena_init(&arena);
+  alloc = upb_arena_alloc(&arena);
+  serialized_input = upb_malloc(alloc, input_size);
 
   if (!CheckedRead(STDIN_FILENO, serialized_input, input_size)) {
     fprintf(stderr, "conformance_upb: unexpected EOF on stdin.\n");
@@ -152,18 +154,18 @@ bool DoTestIo() {
   }
 
   request = conformance_ConformanceRequest_parsenew(
-      upb_stringview_make(serialized_input, input_size), &env);
-  response = conformance_ConformanceResponse_new(&env);
+      upb_stringview_make(serialized_input, input_size), &arena);
+  response = conformance_ConformanceResponse_new(&arena);
 
   if (request) {
-    DoTest(request, response, &env);
+    DoTest(request, response, &arena);
   } else {
     fprintf(stderr, "conformance_upb: parse of ConformanceRequest failed: %s\n",
             upb_status_errmsg(&status));
   }
 
   serialized_output = conformance_ConformanceResponse_serialize(
-      response, &env, &output_size);
+      response, &arena, &output_size);
 
   CheckedWrite(STDOUT_FILENO, &output_size, sizeof(uint32_t));
   CheckedWrite(STDOUT_FILENO, serialized_output, output_size);

--- a/tools/amalgamate.py
+++ b/tools/amalgamate.py
@@ -12,14 +12,20 @@ def parse_include(line):
 class Amalgamator:
   def __init__(self, include_path, output_path):
     self.include_path = include_path
-    self.included = set()
+    self.included = set(["upb/port_def.inc", "upb/port_undef.inc"])
     self.output_h = open(output_path + "upb.h", "w")
     self.output_c = open(output_path + "upb.c", "w")
 
     self.output_c.write("// Amalgamated source file\n")
     self.output_c.write('#include "upb.h"\n')
+    self.output_c.write('#include "upb/port_def.inc"\n')
 
     self.output_h.write("// Amalgamated source file\n")
+    self.output_h.write('#include "upb/port_def.inc"\n')
+
+  def finish(self):
+    self.output_c.write('#include "upb/port_undef.inc"\n')
+    self.output_h.write('#include "upb/port_undef.inc"\n')
 
   def _process_file(self, infile_name, outfile):
     for line in open(infile_name):
@@ -46,3 +52,5 @@ amalgamator = Amalgamator(include_path, output_path)
 
 for filename in sys.argv[3:]:
   amalgamator.add_src(filename.strip())
+
+amalgamator.finish()

--- a/tools/make_c_api.lua
+++ b/tools/make_c_api.lua
@@ -357,7 +357,9 @@ local function write_h_file(filedef, append)
     end
   end
 
+  append('\n')
   append("/* Enums */\n\n")
+
   for _, def in ipairs(sorted_defs(filedef:defs(upb.DEF_ENUM))) do
     local cident = to_cident(def:full_name())
     append('typedef enum {\n')
@@ -434,7 +436,7 @@ local function write_h_file(filedef, append)
     append('\n\n')
   end
 
-  append('UPB_END_EXTERN_C')
+  append('UPB_END_EXTERN_C\n')
 
   append('\n')
   append('#include "upb/port_undef.inc"\n');
@@ -448,13 +450,15 @@ local function write_c_file(filedef, hfilename, append)
 
   append('#include <stddef.h>\n')
   append('#include "upb/msg.h"\n')
-  append('#include "%s"\n\n', hfilename)
+  append('#include "%s"\n', hfilename)
 
   for dep in filedef:dependencies() do
     local outbase = strip_proto(dep:name())
     append('#include "%s.upb.h"\n', outbase)
   end
 
+  append('\n')
+  append('#include "upb/port_def.inc"\n')
   append('\n')
 
   for msg in filedef:defs(upb.DEF_MSG) do
@@ -567,8 +571,12 @@ local function write_c_file(filedef, hfilename, append)
            'false', -- TODO: extendable
           msg:file():syntax() == upb.SYNTAX_PROTO2
           )
+
     append('};\n\n')
   end
+
+  append('#include "upb/port_undef.inc"\n')
+  append('\n')
 end
 
 function export.write_gencode(filedef, hfilename, append_h, append_c)

--- a/upb/bindings/lua/upb/pb.c
+++ b/upb/bindings/lua/upb/pb.c
@@ -29,7 +29,6 @@ static int lupb_pb_encode(lua_State *L) {
   const upb_msg *msg = lupb_msg_checkmsg2(L, 1, &layout);
   upb_arena arena;
   size_t size;
-  upb_status status = UPB_STATUS_INIT;
   char *result;
 
   upb_arena_init(&arena);

--- a/upb/decode.c
+++ b/upb/decode.c
@@ -200,9 +200,19 @@ static void *upb_array_add(upb_array *arr, size_t elements) {
   return ret;
 }
 
+static size_t get_field_offset(const upb_decframe *frame,
+                               const upb_msglayout_field *field) {
+  if (field->oneof_index == UPB_NOT_IN_ONEOF) {
+    return field->offset;
+  } else {
+    return frame->m->oneofs[field->oneof_index].data_offset;
+  }
+}
+
 static upb_array *upb_getarr(upb_decframe *frame,
                              const upb_msglayout_field *field) {
   UPB_ASSERT(field->label == UPB_LABEL_REPEATED);
+  UPB_ASSERT(field->oneof_index == UPB_NOT_IN_ONEOF);
   return *(upb_array**)&frame->msg[field->offset];
 }
 
@@ -237,7 +247,7 @@ static void upb_setoneofcase(upb_decframe *frame,
 
 static char *upb_decode_prepareslot(upb_decstate *d, upb_decframe *frame,
                                     const upb_msglayout_field *field) {
-  char *field_mem = frame->msg + field->offset;
+  char *field_mem = frame->msg + get_field_offset(frame, field);
   upb_array *arr;
 
   if (field->label == UPB_LABEL_REPEATED) {

--- a/upb/decode.c
+++ b/upb/decode.c
@@ -245,7 +245,7 @@ static void upb_setoneofcase(upb_decframe *frame,
             field->number);
 }
 
-static char *upb_decode_prepareslot(upb_decstate *d, upb_decframe *frame,
+static char *upb_decode_prepareslot(upb_decframe *frame,
                                     const upb_msglayout_field *field) {
   char *field_mem = frame->msg + get_field_offset(frame, field);
   upb_array *arr;
@@ -275,7 +275,7 @@ static bool upb_decode_submsg(upb_decstate *d, upb_decframe *frame,
                               const char *limit,
                               const upb_msglayout_field *field,
                               int group_number) {
-  char *submsg_slot = upb_decode_prepareslot(d, frame, field);
+  char *submsg_slot = upb_decode_prepareslot(frame, field);
   char *submsg = *(void **)submsg_slot;
   const upb_msglayout *subm;
 
@@ -300,7 +300,7 @@ static bool upb_decode_varintfield(upb_decstate *d, upb_decframe *frame,
   uint64_t val;
   void *field_mem;
 
-  field_mem = upb_decode_prepareslot(d, frame, field);
+  field_mem = upb_decode_prepareslot(frame, field);
   CHK(field_mem);
   CHK(upb_decode_varint(&d->ptr, frame->limit, &val));
 
@@ -345,7 +345,7 @@ static bool upb_decode_64bitfield(upb_decstate *d, upb_decframe *frame,
   void *field_mem;
   uint64_t val;
 
-  field_mem = upb_decode_prepareslot(d, frame, field);
+  field_mem = upb_decode_prepareslot(frame, field);
   CHK(field_mem);
   CHK(upb_decode_64bit(&d->ptr, frame->limit, &val));
 
@@ -369,7 +369,7 @@ static bool upb_decode_32bitfield(upb_decstate *d, upb_decframe *frame,
   void *field_mem;
   uint32_t val;
 
-  field_mem = upb_decode_prepareslot(d, frame, field);
+  field_mem = upb_decode_prepareslot(frame, field);
   CHK(field_mem);
   CHK(upb_decode_32bit(&d->ptr, frame->limit, &val));
 
@@ -494,7 +494,7 @@ static bool upb_decode_delimitedfield(upb_decstate *d, upb_decframe *frame,
     switch ((upb_descriptortype_t)field->descriptortype) {
       case UPB_DESCRIPTOR_TYPE_STRING:
       case UPB_DESCRIPTOR_TYPE_BYTES: {
-        void *field_mem = upb_decode_prepareslot(d, frame, field);
+        void *field_mem = upb_decode_prepareslot(frame, field);
         CHK(field_mem);
         memcpy(field_mem, &val, sizeof(val));
         break;

--- a/upb/decode.c
+++ b/upb/decode.c
@@ -216,7 +216,7 @@ static upb_array *upb_getarr(upb_decframe *frame,
   return *(upb_array**)&frame->msg[field->offset];
 }
 
-static upb_array *upb_getorcreatearr(upb_decstate *d, upb_decframe *frame,
+static upb_array *upb_getorcreatearr(upb_decframe *frame,
                                      const upb_msglayout_field *field) {
   upb_array *arr = upb_getarr(frame, field);
 
@@ -251,7 +251,7 @@ static char *upb_decode_prepareslot(upb_decstate *d, upb_decframe *frame,
   upb_array *arr;
 
   if (field->label == UPB_LABEL_REPEATED) {
-    arr = upb_getorcreatearr(d, frame, field);
+    arr = upb_getorcreatearr(frame, field);
     field_mem = upb_array_reserve(arr, 1);
   }
 
@@ -403,7 +403,7 @@ static bool upb_decode_toarray(upb_decstate *d, upb_decframe *frame,
                                const char *field_start,
                                const upb_msglayout_field *field,
                                upb_stringview val) {
-  upb_array *arr = upb_getorcreatearr(d, frame, field);
+  upb_array *arr = upb_getorcreatearr(frame, field);
 
 #define VARINT_CASE(ctype, decode) { \
   const char *ptr = val.data; \

--- a/upb/decode.c
+++ b/upb/decode.c
@@ -28,7 +28,6 @@ const uint8_t upb_desctype_to_fieldtype[] = {
 
 /* Data pertaining to the parse. */
 typedef struct {
-  upb_env *env;
   /* Current decoding pointer.  Points to the beginning of a field until we
    * have finished decoding the whole field. */
   const char *ptr;
@@ -213,7 +212,7 @@ static upb_array *upb_getorcreatearr(upb_decstate *d, upb_decframe *frame,
 
   if (!arr) {
     upb_fieldtype_t type = upb_desctype_to_fieldtype[field->descriptortype];
-    arr = upb_array_new(type, upb_env_arena(d->env));
+    arr = upb_array_new(type, upb_msg_arena(frame->msg));
     if (!arr) {
       return NULL;
     }
@@ -275,7 +274,7 @@ static bool upb_decode_submsg(upb_decstate *d, upb_decframe *frame,
   UPB_ASSERT(subm);
 
   if (!submsg) {
-    submsg = upb_msg_new((upb_msglayout *)subm, upb_env_arena(d->env));
+    submsg = upb_msg_new(subm, upb_msg_arena(frame->msg));
     CHK(submsg);
     *(void**)submsg_slot = submsg;
   }
@@ -455,7 +454,7 @@ static bool upb_decode_toarray(upb_decstate *d, upb_decframe *frame,
       subm = frame->m->submsgs[field->submsg_index];
       UPB_ASSERT(subm);
 
-      submsg = upb_msg_new((upb_msglayout *)subm, upb_env_arena(d->env));
+      submsg = upb_msg_new(subm, upb_msg_arena(frame->msg));
       CHK(submsg);
 
       field_mem = upb_array_add(arr, 1);
@@ -587,11 +586,9 @@ static bool upb_decode_message(upb_decstate *d, const char *limit,
   return true;
 }
 
-bool upb_decode(upb_stringview buf, void *msg, const upb_msglayout *l,
-                upb_env *env) {
+bool upb_decode(upb_stringview buf, void *msg, const upb_msglayout *l) {
   upb_decstate state;
   state.ptr = buf.data;
-  state.env = env;
 
   return upb_decode_message(&state, buf.data + buf.size, 0, msg, l);
 }

--- a/upb/decode.h
+++ b/upb/decode.h
@@ -9,8 +9,7 @@
 
 UPB_BEGIN_EXTERN_C
 
-bool upb_decode(upb_stringview buf, void *msg, const upb_msglayout *l,
-                upb_env *env);
+bool upb_decode(upb_stringview buf, upb_msg *msg, const upb_msglayout *l);
 
 UPB_END_EXTERN_C
 

--- a/upb/encode.c
+++ b/upb/encode.c
@@ -47,7 +47,7 @@ static uint32_t upb_zzencode_32(int32_t n) { return (n << 1) ^ (n >> 31); }
 static uint64_t upb_zzencode_64(int64_t n) { return (n << 1) ^ (n >> 63); }
 
 typedef struct {
-  upb_env *env;
+  upb_alloc *alloc;
   char *buf, *ptr, *limit;
 } upb_encstate;
 
@@ -62,7 +62,7 @@ static size_t upb_roundup_pow2(size_t bytes) {
 static bool upb_encode_growbuffer(upb_encstate *e, size_t bytes) {
   size_t old_size = e->limit - e->buf;
   size_t new_size = upb_roundup_pow2(bytes + (e->limit - e->ptr));
-  char *new_buf = upb_env_realloc(e->env, e->buf, old_size, new_size);
+  char *new_buf = upb_realloc(e->alloc, e->buf, old_size, new_size);
   CHK(new_buf);
 
   /* We want previous data at the end, realloc() put it at the beginning. */
@@ -371,10 +371,10 @@ bool upb_encode_message(upb_encstate *e, const char *msg,
   return true;
 }
 
-char *upb_encode(const void *msg, const upb_msglayout *m, upb_env *env,
+char *upb_encode(const void *msg, const upb_msglayout *m, upb_arena *arena,
                  size_t *size) {
   upb_encstate e;
-  e.env = env;
+  e.alloc = upb_arena_alloc(arena);
   e.buf = NULL;
   e.limit = NULL;
   e.ptr = NULL;

--- a/upb/encode.h
+++ b/upb/encode.h
@@ -9,7 +9,7 @@
 
 UPB_BEGIN_EXTERN_C
 
-char *upb_encode(const void *msg, const upb_msglayout *l, upb_env *env,
+char *upb_encode(const void *msg, const upb_msglayout *l, upb_arena *arena,
                  size_t *size);
 
 UPB_END_EXTERN_C

--- a/upb/port_def.inc
+++ b/upb/port_def.inc
@@ -1,0 +1,18 @@
+
+#if UINTPTR_MAX == 0xffffffff
+#define UPB_SIZE(size32, size64) size32
+#else
+#define UPB_SIZE(size32, size64) size64
+#endif
+
+#define UPB_FIELD_AT(msg, fieldtype, offset) \
+  *(fieldtype*)((const char*)(msg) + offset)
+
+#define UPB_READ_ONEOF(msg, fieldtype, offset, case_offset, case_val, default) \
+  UPB_FIELD_AT(msg, int, case_offset) == case_val                              \
+      ? UPB_FIELD_AT(msg, fieldtype, offset)                                   \
+      : default
+
+#define UPB_WRITE_ONEOF(msg, fieldtype, offset, value, case_offset, case_val) \
+  UPB_FIELD_AT(msg, int, case_offset) = case_val;                             \
+  UPB_FIELD_AT(msg, fieldtype, offset) = value;

--- a/upb/port_undef.inc
+++ b/upb/port_undef.inc
@@ -1,0 +1,5 @@
+
+#undef UPB_SIZE
+#undef UPB_FIELD_AT
+#undef UPB_READ_ONEOF
+#undef UPB_WRITE_ONEOF


### PR DESCRIPTION
This makes C client code read more nicely. See conformance_upb.c for an example.

The downside is that it prevents us from changing the internal representation except to reorder struct fields.