### PR TITLE
Adding support for big endian platform (s390x)

### DIFF
--- a/tests/pb/test_varint.c
+++ b/tests/pb/test_varint.c
@@ -20,6 +20,25 @@ static void test_varint_for_num(upb_decoderet (*decoder)(const char*),
 
     memset(buf2, 0, sizeof(buf2));
     memcpy(&buf2, &encoded, 8);
+#ifdef UPB_BIG_ENDIAN
+    char swap[8];
+    swap[0] = buf2[7];
+    swap[1] = buf2[6];
+    swap[2] = buf2[5];
+    swap[3] = buf2[4];
+    swap[4] = buf2[3];
+    swap[5] = buf2[2];
+    swap[6] = buf2[1];
+    swap[7] = buf2[0];
+    buf2[0] = swap[0];
+    buf2[1] = swap[1];
+    buf2[2] = swap[2];
+    buf2[3] = swap[3];
+    buf2[4] = swap[4];
+    buf2[5] = swap[5];
+    buf2[6] = swap[6];
+    buf2[7] = swap[7];
+#endif    
     r = decoder(buf2);
     ASSERT(r.val == num);
     ASSERT(r.p == buf2 + upb_value_size(encoded));

--- a/upb/pb/varint.int.h
+++ b/upb/pb/varint.int.h
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <stdint.h>
 #include <string.h>
+#include <byteswap.h>
 #include "upb/upb.h"
 
 #ifdef __cplusplus
@@ -130,6 +131,9 @@ UPB_INLINE uint64_t upb_vencode32(uint32_t val) {
   uint64_t ret = 0;
   UPB_ASSERT(bytes <= 5);
   memcpy(&ret, buf, bytes);
+#ifdef UPB_BIG_ENDIAN
+  ret = bswap_64(ret);
+#endif
   UPB_ASSERT(ret <= 0xffffffffffU);
   return ret;
 }

--- a/upb/pb/varint.int.h
+++ b/upb/pb/varint.int.h
@@ -9,7 +9,6 @@
 #include <assert.h>
 #include <stdint.h>
 #include <string.h>
-#include <byteswap.h>
 #include "upb/upb.h"
 
 #ifdef __cplusplus
@@ -24,6 +23,18 @@ extern "C" {
 /* Array of the "native" (ie. non-packed-repeated) wire type for the given a
  * descriptor type (upb_descriptortype_t). */
 extern const uint8_t upb_pb_native_wire_types[];
+
+UPB_INLINE uint64_t byteswap64(uint64_t val)
+{
+  return ((((val) & 0xff00000000000000ull) >> 56)
+    | (((val) & 0x00ff000000000000ull) >> 40)
+    | (((val) & 0x0000ff0000000000ull) >> 24)
+    | (((val) & 0x000000ff00000000ull) >> 8)
+    | (((val) & 0x00000000ff000000ull) << 8)
+    | (((val) & 0x0000000000ff0000ull) << 24)
+    | (((val) & 0x000000000000ff00ull) << 40)
+    | (((val) & 0x00000000000000ffull) << 56));
+}
 
 /* Zig-zag encoding/decoding **************************************************/
 
@@ -132,7 +143,7 @@ UPB_INLINE uint64_t upb_vencode32(uint32_t val) {
   UPB_ASSERT(bytes <= 5);
   memcpy(&ret, buf, bytes);
 #ifdef UPB_BIG_ENDIAN
-  ret = bswap_64(ret);
+  ret = byteswap64(ret);
 #endif
   UPB_ASSERT(ret <= 0xffffffffffU);
   return ret;

--- a/upb/table.c
+++ b/upb/table.c
@@ -726,7 +726,7 @@ bool upb_inttable_iter_isequal(const upb_inttable_iter *i1,
          i1->array_part == i2->array_part;
 }
 
-#ifdef UPB_UNALIGNED_READS_OK
+#if defined(UPB_UNALIGNED_READS_OK) || defined(__s390x__)
 /* -----------------------------------------------------------------------------
  * MurmurHash2, by Austin Appleby (released as public domain).
  * Reformatted and C99-ified by Joshua Haberman.


### PR DESCRIPTION
These changes will fix following tests which currently are failing for big endian architecture (s390x):
1. test_varint
2. test_json

The changes made are:
1. tests/pb/test_varint.c => Correcting the input data for big endian. 
2. upb/pb/varint.int.h => Reversing the order of bytes to correct the data representation for big endian. 
3. upb/table.c => Choosing the MurmurHash2 over MurmurHashAligned2 as it is not working correctly fro s390x architecture at present.
